### PR TITLE
feat: add client expiration check to update client before expired

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3379,10 +3379,11 @@
       "license": "MIT"
     },
     "node_modules/cross-spawn": {
-      "version": "7.0.3",
-      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.3.tgz",
-      "integrity": "sha512-iRDPJKUPVEND7dHPO8rkbOnPpyDygcDFtWjpeWNCgy8WP2rXcxXL8TskReQl6OrB2G7+UJrags1q15Fudc7G6w==",
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
+      "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "path-key": "^3.1.0",
         "shebang-command": "^2.0.0",
@@ -4023,9 +4024,9 @@
       }
     },
     "node_modules/express": {
-      "version": "4.21.1",
-      "resolved": "https://registry.npmjs.org/express/-/express-4.21.1.tgz",
-      "integrity": "sha512-YSFlK1Ee0/GC8QaO91tHcDxJiE/X4FbpAyQWkxAvG6AXCuR65YzK8ua6D9hvi/TzUfZMpc+BwuM1IPw8fmQBiQ==",
+      "version": "4.21.2",
+      "resolved": "https://registry.npmjs.org/express/-/express-4.21.2.tgz",
+      "integrity": "sha512-28HqgMZAmih1Czt9ny7qr6ek2qddF4FclbMzwhCREB6OFfH+rXAnuNCwo1/wFvrtbgsQDb4kSbX9de9lFbrXnA==",
       "license": "MIT",
       "dependencies": {
         "accepts": "~1.3.8",
@@ -4047,7 +4048,7 @@
         "methods": "~1.1.2",
         "on-finished": "2.4.1",
         "parseurl": "~1.3.3",
-        "path-to-regexp": "0.1.10",
+        "path-to-regexp": "0.1.12",
         "proxy-addr": "~2.0.7",
         "qs": "6.13.0",
         "range-parser": "~1.2.1",
@@ -4062,6 +4063,10 @@
       },
       "engines": {
         "node": ">= 0.10.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
       }
     },
     "node_modules/fast-deep-equal": {
@@ -6354,9 +6359,9 @@
       "license": "MIT"
     },
     "node_modules/path-to-regexp": {
-      "version": "0.1.10",
-      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.10.tgz",
-      "integrity": "sha512-7lf7qcQidTku0Gu3YDPc8DJ1q7OOucfa/BSsIwjuh56VU7katFvuM8hULfkwB3Fns/rsVF7PwPKVw1sl5KQS9w==",
+      "version": "0.1.12",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.12.tgz",
+      "integrity": "sha512-RA1GjUVMnvYFxuqovrEqZoxxW5NUZqbwKtYz/Tt7nXerk0LbLblQmrsgdeOxV5SFHf0UDggjS/bSeOZwt1pmEQ==",
       "license": "MIT"
     },
     "node_modules/path-type": {

--- a/src/db/controller/channel.ts
+++ b/src/db/controller/channel.ts
@@ -87,7 +87,7 @@ export class ChannelController {
 
     return select<ChannelOpenCloseTable>(
       DB,
-      this.tableName,
+      ChannelController.tableName,
       wheres,
       { id: 'ASC' },
       limit
@@ -103,7 +103,7 @@ export class ChannelController {
 
     del<ChannelOpenCloseTable>(
       DB,
-      this.tableName,
+      ChannelController.tableName,
       events.map((v) => ({ id: v.id as number }))
     )
   }
@@ -111,7 +111,7 @@ export class ChannelController {
   public static updateInProgress(id?: number, inProgress = true) {
     update<ChannelOpenCloseTable>(
       DB,
-      this.tableName,
+      ChannelController.tableName,
       { in_progress: inProgress ? Bool.TRUE : Bool.FALSE },
       [{ id }]
     )
@@ -119,7 +119,7 @@ export class ChannelController {
 
   public static resetPacketInProgress(db?: Database) {
     db = db ?? DB
-    update<ChannelOpenCloseTable>(db, this.tableName, {
+    update<ChannelOpenCloseTable>(db, ChannelController.tableName, {
       in_progress: Bool.FALSE,
     })
   }
@@ -152,7 +152,7 @@ export class ChannelController {
     }
 
     return () => {
-      insert(DB, this.tableName, channelOnOpen) // store INIT state to the dst chain
+      insert(DB, ChannelController.tableName, channelOnOpen) // store INIT state to the dst chain
     }
   }
 
@@ -184,7 +184,7 @@ export class ChannelController {
     }
 
     return () => {
-      del<ChannelOpenCloseTable>(DB, this.tableName, [
+      del<ChannelOpenCloseTable>(DB, ChannelController.tableName, [
         {
           state: ChannelState.INIT,
           counterparty_chain_id: connection.counterparty_chain_id,
@@ -192,7 +192,7 @@ export class ChannelController {
           counterparty_channel_id: channelOnOpen.channel_id,
         },
       ]) // remove INIT from the dst chain
-      insert(DB, this.tableName, channelOnOpen) // store TRYOPEN state to the src chain
+      insert(DB, ChannelController.tableName, channelOnOpen) // store TRYOPEN state to the src chain
     }
   }
 
@@ -224,7 +224,7 @@ export class ChannelController {
     }
 
     return () => {
-      del<ChannelOpenCloseTable>(DB, this.tableName, [
+      del<ChannelOpenCloseTable>(DB, ChannelController.tableName, [
         {
           state: ChannelState.TRYOPEN,
           counterparty_chain_id: channelOnOpen.chain_id,
@@ -232,7 +232,7 @@ export class ChannelController {
           counterparty_channel_id: channelOnOpen.channel_id,
         },
       ]) // remove TRYOPEN from src chain
-      del<ChannelOpenCloseTable>(DB, this.tableName, [
+      del<ChannelOpenCloseTable>(DB, ChannelController.tableName, [
         {
           state: ChannelState.INIT,
           counterparty_chain_id: chainId,
@@ -240,7 +240,7 @@ export class ChannelController {
           counterparty_channel_id: channelOnOpen.counterparty_channel_id,
         },
       ]) // remove INIT from dst chain
-      insert(DB, this.tableName, channelOnOpen) // store ACK state to the dst chain
+      insert(DB, ChannelController.tableName, channelOnOpen) // store ACK state to the dst chain
     }
   }
 
@@ -256,7 +256,7 @@ export class ChannelController {
       event.channelOpenCloseInfo.dstConnectionId
     )
     return () => {
-      del<ChannelOpenCloseTable>(DB, this.tableName, [
+      del<ChannelOpenCloseTable>(DB, ChannelController.tableName, [
         {
           state: ChannelState.TRYOPEN,
           counterparty_chain_id: chainId,
@@ -264,7 +264,7 @@ export class ChannelController {
           counterparty_channel_id: event.channelOpenCloseInfo.dstChannelId,
         },
       ]) // remove TRYOPEN from src chain
-      del<ChannelOpenCloseTable>(DB, this.tableName, [
+      del<ChannelOpenCloseTable>(DB, ChannelController.tableName, [
         {
           state: ChannelState.ACK,
           counterparty_chain_id: connection.counterparty_chain_id,
@@ -302,7 +302,7 @@ export class ChannelController {
     }
 
     return () => {
-      insert(DB, this.tableName, channelOnOpen)
+      insert(DB, ChannelController.tableName, channelOnOpen)
 
       // Mark all packets as timed out
       PacketController.updateTimeout(
@@ -318,7 +318,7 @@ export class ChannelController {
     event: ChannelOpenCloseEvent
   ): () => void {
     return () => {
-      del<ChannelOpenCloseTable>(DB, this.tableName, [
+      del<ChannelOpenCloseTable>(DB, ChannelController.tableName, [
         {
           state: ChannelState.CLOSE,
           chain_id: chainId,

--- a/src/db/controller/client.spec.ts
+++ b/src/db/controller/client.spec.ts
@@ -1,0 +1,53 @@
+import { ClientTable } from 'src/types'
+import { DB } from '..'
+import { insert } from '../utils'
+import { mockServers } from 'src/test/testSetup'
+import { ClientController } from './client'
+
+describe('client controller', () => {
+  mockServers // to set set config file
+  test('client controller e2e', async () => {
+    const currentTimestamp = Math.floor(new Date().valueOf() / 1000)
+    // add clients for test
+    const testClients: ClientTable[] = [
+      {
+        chain_id: 'chain-1',
+        client_id: 'client-1',
+        counterparty_chain_id: 'chain-2',
+        revision_height: 1,
+        trusting_period: 3000,
+        last_update_time: currentTimestamp - 2500, // need update
+      },
+
+      {
+        chain_id: 'chain-1',
+        client_id: 'client-2',
+        counterparty_chain_id: 'chain-2',
+        revision_height: 1,
+        trusting_period: 3000,
+        last_update_time: currentTimestamp - 500, // do not need to update
+      },
+
+      {
+        chain_id: 'chain-1',
+        client_id: 'client-3',
+        counterparty_chain_id: 'chain-2',
+        revision_height: 1,
+        trusting_period: 3000,
+        last_update_time: currentTimestamp - 3500, // expired
+      },
+    ]
+
+    testClients.map((client) => {
+      insert(DB, ClientController.tableName, client)
+    })
+
+    // get clients to update
+    const clientsToUpdate = ClientController.getClientsToUpdate('chain-1', [
+      'chain-2',
+    ])
+
+    // check clients to update
+    expect(clientsToUpdate.map((v) => v.client_id)).toEqual(['client-1'])
+  })
+})

--- a/src/db/controller/client.ts
+++ b/src/db/controller/client.ts
@@ -58,7 +58,7 @@ export class ClientController {
     const client = await this.getClient(rest, chainId, clientId)
 
     // update client
-    const splitted = event.consensusHeights.split(',')[0].split('-')[1]
+    const splitted = event.consensusHeights.split(',')[0].split('-')
     if (splitted.length < 2) {
       throw new Error(
         'Invalid consensusHeights format. Expected "revision-height"'

--- a/src/db/controller/client.ts
+++ b/src/db/controller/client.ts
@@ -27,7 +27,7 @@ export class ClientController {
       last_update_time: 0,
     }
 
-    insert(DB, this.tableName, client)
+    insert(DB, ClientController.tableName, client)
 
     return client
   }
@@ -68,7 +68,7 @@ export class ClientController {
 
     update<ClientTable>(
       DB,
-      this.tableName,
+      ClientController.tableName,
       {
         revision_height: client.revision_height,
         last_update_time: client.last_update_time,
@@ -88,7 +88,7 @@ export class ClientController {
     clientId: string
   ): Promise<ClientTable> {
     // get client
-    const client = selectOne<ClientTable>(DB, this.tableName, [
+    const client = selectOne<ClientTable>(DB, ClientController.tableName, [
       {
         chain_id: chainId,
         client_id: clientId,
@@ -104,7 +104,7 @@ export class ClientController {
   ): ClientTable[] {
     const clients = select<ClientTable>(
       DB,
-      this.tableName,
+      ClientController.tableName,
       counterpartyChainIds.map((counterpartyChainId) => ({
         chain_id: chainId,
         counterparty_chain_id: counterpartyChainId,

--- a/src/db/controller/client.ts
+++ b/src/db/controller/client.ts
@@ -5,6 +5,7 @@ import { UpdateClientEvent, ClientTable } from 'src/types'
 import { Header } from 'cosmjs-types/ibc/lightclients/tendermint/v1/tendermint'
 import { RESTClient } from 'src/lib/restClient'
 import { PacketController } from './packet'
+import { ChannelController } from './channel'
 
 export class ClientController {
   static tableName = 'client'
@@ -33,8 +34,10 @@ export class ClientController {
     ])
     insert(DB, ClientController.tableName, client)
 
-    // to recheck expired packets
+    // to recheck packets
     PacketController.resetPacketInProgress()
+    // to recheck channel
+    ChannelController.resetPacketInProgress()
 
     return client
   }

--- a/src/db/controller/client.ts
+++ b/src/db/controller/client.ts
@@ -58,9 +58,14 @@ export class ClientController {
     const client = await this.getClient(rest, chainId, clientId)
 
     // update client
-    const revisionHeight = parseInt(
-      event.consensusHeights.split(',')[0].split('-')[1]
-    )
+    const splitted = event.consensusHeights.split(',')[0].split('-')[1]
+    if (splitted.length < 2) {
+      throw new Error(
+        'Invalid consensusHeights format. Expected "revision-height"'
+      )
+    }
+
+    const revisionHeight = parseInt(splitted[1])
 
     if (revisionHeight > client.revision_height) {
       client.revision_height = revisionHeight

--- a/src/db/controller/connection.ts
+++ b/src/db/controller/connection.ts
@@ -25,7 +25,7 @@ export class ConnectionController {
       counterparty_client_id: connectionInfo.connection.counterparty.client_id,
     }
 
-    insert(DB, this.tableName, connection)
+    insert(DB, ConnectionController.tableName, connection)
 
     return connection
   }
@@ -37,12 +37,16 @@ export class ConnectionController {
     chainId: string,
     connectionId: string
   ): Promise<ConnectionTable> {
-    const connection = selectOne<ConnectionTable>(DB, this.tableName, [
-      {
-        chain_id: chainId,
-        connection_id: connectionId,
-      },
-    ])
+    const connection = selectOne<ConnectionTable>(
+      DB,
+      ConnectionController.tableName,
+      [
+        {
+          chain_id: chainId,
+          connection_id: connectionId,
+        },
+      ]
+    )
 
     return connection ?? this.addConnection(rest, chainId, connectionId)
   }

--- a/src/db/controller/packet.spec.ts
+++ b/src/db/controller/packet.spec.ts
@@ -1,108 +1,70 @@
-import { FeeType, PacketFeeTable } from 'src/types'
+import { Bool, PacketEvent, PacketSendTable } from 'src/types'
 import { DB } from '..'
 import { select } from '../utils'
+import { PacketController } from './packet'
 import { mockServers } from 'src/test/testSetup'
-import { parsePacketFeeEvent } from 'src/lib/eventParser'
-import { PacketFeeController } from './packetFee'
 
-describe('packet controler', () => {
+describe('channel controler', () => {
   test('packet send e2e', async () => {
-    const [mockServer1, _] = mockServers
+    const [mockServer1] = mockServers
+    // test send_packet
+    {
+      // create mock events
+      const events: PacketEvent[] = [
+        {
+          type: 'send_packet',
+          packetInfo: {
+            height: 100,
+            sequence: 1,
+            connectionId: 'connection-1',
+            srcPort: 'transfer',
+            srcChannel: 'channel-1',
+            dstPort: 'transfer',
+            data: 'e2RhdGE6IG51bGx9',
+            dstChannel: 'channel-2',
+            timeoutHeight: 0,
+            timeoutTimestamp: 1731051545,
+            timeoutHeightRaw: '0-0',
+            timeoutTimestampRaw: '1731051545000000000',
+          },
+        },
+      ]
 
-    const event = parsePacketFeeEvent({
-      type: 'incentivized_ibc_packet',
-      attributes: [
-        {
-          key: 'port_id',
-          value: 'transfer',
-        },
-        {
-          key: 'channel_id',
-          value: 'channel-1',
-        },
-        {
-          key: 'packet_sequence',
-          value: '1',
-        },
-        {
-          key: 'recv_fee',
-          value: '100tokena,200tokenb',
-        },
-        {
-          key: 'ack_fee',
-          value: '200tokena,100tokenb',
-        },
-        {
-          key: 'timeout_fee',
-          value: '300tokena,300tokenb',
-        },
-        {
-          key: 'msg_index',
-          value: '0',
-        },
-      ],
-    })
+      // create feed functions
+      const fns = await PacketController.feedEvents(
+        mockServer1.rest.client(),
+        mockServer1.rest.chainId,
+        events
+      )
 
-    // create feed functions
-    const fns = PacketFeeController.feedEvents(mockServer1.rest.chainId, [
-      event,
-    ])
+      // execute feed functions
+      fns()
 
-    // execute feed functions
-    fns()
+      // check db insertion
+      const res = select(DB, PacketController.tableNamePacketSend)
+      const expectVal: PacketSendTable[] = [
+        {
+          dst_chain_id: 'chain-2',
+          dst_connection_id: 'connection-2',
+          dst_channel_id: 'channel-2',
+          sequence: 1,
+          in_progress: Bool.FALSE,
+          is_ordered: Bool.FALSE,
+          height: 100,
+          dst_port: 'transfer',
+          src_chain_id: 'chain-1',
+          src_connection_id: 'connection-1',
+          src_port: 'transfer',
+          src_channel_id: 'channel-1',
+          packet_data: 'e2RhdGE6IG51bGx9',
+          timeout_height: 0,
+          timeout_timestamp: 1731051545,
+          timeout_height_raw: '0-0',
+          timeout_timestamp_raw: '1731051545000000000',
+        },
+      ]
 
-    // check db insertion
-    const res = select(DB, PacketFeeController.tableName)
-    const expectVal: PacketFeeTable[] = [
-      {
-        chain_id: mockServer1.rest.chainId,
-        channel_id: 'channel-1',
-        sequence: event.sequence,
-        fee_type: FeeType.RECV,
-        denom: 'tokena',
-        amount: 100,
-      },
-      {
-        chain_id: mockServer1.rest.chainId,
-        channel_id: 'channel-1',
-        sequence: event.sequence,
-        fee_type: FeeType.RECV,
-        denom: 'tokenb',
-        amount: 200,
-      },
-      {
-        chain_id: mockServer1.rest.chainId,
-        channel_id: 'channel-1',
-        sequence: event.sequence,
-        fee_type: FeeType.ACK,
-        denom: 'tokena',
-        amount: 200,
-      },
-      {
-        chain_id: mockServer1.rest.chainId,
-        channel_id: 'channel-1',
-        sequence: event.sequence,
-        fee_type: FeeType.ACK,
-        denom: 'tokenb',
-        amount: 100,
-      },
-      {
-        chain_id: mockServer1.rest.chainId,
-        channel_id: 'channel-1',
-        sequence: event.sequence,
-        fee_type: FeeType.TIMEOUT,
-        denom: 'tokena',
-        amount: 300,
-      },
-      {
-        chain_id: mockServer1.rest.chainId,
-        channel_id: 'channel-1',
-        sequence: event.sequence,
-        fee_type: FeeType.TIMEOUT,
-        denom: 'tokenb',
-        amount: 300,
-      },
-    ]
-    expect(res).toEqual(expectVal)
+      expect(res).toEqual(expectVal)
+    }
   })
 })

--- a/src/db/controller/packet.ts
+++ b/src/db/controller/packet.ts
@@ -104,7 +104,7 @@ export class PacketController {
       res.push(
         ...select<PacketSendTable>(
           DB,
-          this.tableNamePacketSend,
+          PacketController.tableNamePacketSend,
           wheres,
           { sequence: 'ASC' },
           limit - res.length
@@ -159,7 +159,7 @@ export class PacketController {
 
     return select<PacketTimeoutTable>(
       DB,
-      this.tableNamePacketTimeout,
+      PacketController.tableNamePacketTimeout,
       wheres,
       { sequence: 'ASC' },
       limit
@@ -207,7 +207,7 @@ export class PacketController {
 
     return select<PacketWriteAckTable>(
       DB,
-      this.tableNamePacketWriteAck,
+      PacketController.tableNamePacketWriteAck,
       wheres,
       { sequence: 'ASC' },
       limit
@@ -218,7 +218,7 @@ export class PacketController {
     if (packets.length === 0) return
     del<PacketSendTable>(
       DB,
-      this.tableNamePacketSend,
+      PacketController.tableNamePacketSend,
       packets.map((packet) => ({
         dst_chain_id: packet.dst_chain_id,
         dst_connection_id: packet.dst_connection_id,
@@ -232,7 +232,7 @@ export class PacketController {
     if (packets.length === 0) return
     del<PacketTimeoutTable>(
       DB,
-      this.tableNamePacketTimeout,
+      PacketController.tableNamePacketTimeout,
       packets.map((packet) => ({
         src_chain_id: packet.src_chain_id,
         src_connection_id: packet.src_connection_id,
@@ -246,7 +246,7 @@ export class PacketController {
     if (packets.length === 0) return
     del<PacketWriteAckTable>(
       DB,
-      this.tableNamePacketWriteAck,
+      PacketController.tableNamePacketWriteAck,
       packets.map((packet) => ({
         src_chain_id: packet.src_chain_id,
         src_connection_id: packet.src_connection_id,
@@ -262,7 +262,7 @@ export class PacketController {
   ) {
     update<PacketSendTable>(
       DB,
-      this.tableNamePacketSend,
+      PacketController.tableNamePacketSend,
       { in_progress: inProgress ? Bool.TRUE : Bool.FALSE },
       [
         {
@@ -281,7 +281,7 @@ export class PacketController {
   ) {
     update<PacketTimeoutTable>(
       DB,
-      this.tableNamePacketTimeout,
+      PacketController.tableNamePacketTimeout,
       { in_progress: inProgress ? Bool.TRUE : Bool.FALSE },
       [
         {
@@ -300,7 +300,7 @@ export class PacketController {
   ) {
     update<PacketWriteAckTable>(
       DB,
-      this.tableNamePacketWriteAck,
+      PacketController.tableNamePacketWriteAck,
       { in_progress: inProgress ? Bool.TRUE : Bool.FALSE },
       [
         {
@@ -315,13 +315,13 @@ export class PacketController {
 
   public static resetPacketInProgress(db?: Database) {
     db = db ?? DB
-    update<PacketSendTable>(db, this.tableNamePacketSend, {
+    update<PacketSendTable>(db, PacketController.tableNamePacketSend, {
       in_progress: Bool.FALSE,
     })
-    update<PacketTimeoutTable>(db, this.tableNamePacketTimeout, {
+    update<PacketTimeoutTable>(db, PacketController.tableNamePacketTimeout, {
       in_progress: Bool.FALSE,
     })
-    update<PacketWriteAckTable>(db, this.tableNamePacketWriteAck, {
+    update<PacketWriteAckTable>(db, PacketController.tableNamePacketWriteAck, {
       in_progress: Bool.FALSE,
     })
   }
@@ -382,14 +382,14 @@ export class PacketController {
     }
 
     return () => {
-      insert(DB, this.tableNamePacketSend, packetSend)
-      insert(DB, this.tableNamePacketTimeout, packetTimeout)
+      insert(DB, PacketController.tableNamePacketSend, packetSend)
+      insert(DB, PacketController.tableNamePacketTimeout, packetTimeout)
 
       // if channel is ordered channel, update in progress for higher sequence
       if (packetSend.is_ordered === Bool.TRUE) {
         update<PacketSendTable>(
           DB,
-          this.tableNamePacketSend,
+          PacketController.tableNamePacketSend,
           { in_progress: Bool.FALSE },
           [
             {
@@ -438,7 +438,7 @@ export class PacketController {
     }
     return () => {
       // remove pakcet send
-      del<PacketSendTable>(DB, this.tableNamePacketSend, [
+      del<PacketSendTable>(DB, PacketController.tableNamePacketSend, [
         {
           dst_chain_id: chainId,
           dst_channel_id: event.packetInfo.dstChannel,
@@ -460,13 +460,13 @@ export class PacketController {
         FeeType.TIMEOUT
       )
 
-      insert(DB, this.tableNamePacketWriteAck, packetWriteAck)
+      insert(DB, PacketController.tableNamePacketWriteAck, packetWriteAck)
 
       // if channel is ordered channel, update in progress for higher sequence
       if (packetWriteAck.is_ordered === Bool.TRUE) {
         update<PacketSendTable>(
           DB,
-          this.tableNamePacketSend,
+          PacketController.tableNamePacketSend,
           { in_progress: Bool.FALSE },
           [
             {
@@ -493,7 +493,7 @@ export class PacketController {
 
     return () => {
       // remove pakcet send
-      del<PacketSendTable>(DB, this.tableNamePacketSend, [
+      del<PacketSendTable>(DB, PacketController.tableNamePacketSend, [
         {
           dst_chain_id: connection.counterparty_chain_id,
           dst_connection_id: connection.counterparty_connection_id,
@@ -503,7 +503,7 @@ export class PacketController {
       ])
 
       // remove packet timeout
-      del<PacketTimeoutTable>(DB, this.tableNamePacketSend, [
+      del<PacketTimeoutTable>(DB, PacketController.tableNamePacketSend, [
         {
           src_chain_id: chainId,
           src_connection_id: event.packetInfo.connectionId,
@@ -513,7 +513,7 @@ export class PacketController {
       ])
 
       // remove packet write ack
-      del<PacketWriteAckTable>(DB, this.tableNamePacketSend, [
+      del<PacketWriteAckTable>(DB, PacketController.tableNamePacketSend, [
         {
           src_chain_id: chainId,
           src_connection_id: event.packetInfo.connectionId,
@@ -557,7 +557,7 @@ export class PacketController {
     )
     return () => {
       // remove pakcet send
-      del<PacketSendTable>(DB, this.tableNamePacketSend, [
+      del<PacketSendTable>(DB, PacketController.tableNamePacketSend, [
         {
           dst_chain_id: connection.counterparty_chain_id,
           dst_connection_id: connection.counterparty_connection_id,
@@ -567,7 +567,7 @@ export class PacketController {
       ])
 
       // remove packet timeout
-      del<PacketTimeoutTable>(DB, this.tableNamePacketSend, [
+      del<PacketTimeoutTable>(DB, PacketController.tableNamePacketSend, [
         {
           src_chain_id: chainId,
           src_connection_id: event.packetInfo.connectionId,

--- a/src/db/controller/packetFee.spec.ts
+++ b/src/db/controller/packetFee.spec.ts
@@ -1,69 +1,108 @@
-import { Bool, PacketEvent, PacketSendTable } from 'src/types'
+import { FeeType, PacketFeeTable } from 'src/types'
 import { DB } from '..'
 import { select } from '../utils'
-import { PacketController } from './packet'
 import { mockServers } from 'src/test/testSetup'
+import { parsePacketFeeEvent } from 'src/lib/eventParser'
+import { PacketFeeController } from './packetFee'
 
-describe('channel controler', () => {
-  test('packet send e2e', async () => {
-    const [mockServer1, _] = mockServers
-    // test send_packet
-    {
-      // create mock events
-      const events: PacketEvent[] = [
+describe('packet controler', () => {
+  test('packet fee e2e', () => {
+    const [mockServer1] = mockServers
+
+    const event = parsePacketFeeEvent({
+      type: 'incentivized_ibc_packet',
+      attributes: [
         {
-          type: 'send_packet',
-          packetInfo: {
-            height: 100,
-            sequence: 1,
-            connectionId: 'connection-1',
-            srcPort: 'transfer',
-            srcChannel: 'channel-1',
-            dstPort: 'transfer',
-            data: 'e2RhdGE6IG51bGx9',
-            dstChannel: 'channel-2',
-            timeoutHeight: 0,
-            timeoutTimestamp: 1731051545,
-            timeoutHeightRaw: '0-0',
-            timeoutTimestampRaw: '1731051545000000000',
-          },
+          key: 'port_id',
+          value: 'transfer',
         },
-      ]
-
-      // create feed functions
-      const fns = await PacketController.feedEvents(
-        mockServer1.rest.client(),
-        mockServer1.rest.chainId,
-        events
-      )
-
-      // execute feed functions
-      fns()
-
-      // check db insertion
-      const res = select(DB, PacketController.tableNamePacketSend)
-      const expectVal: PacketSendTable[] = [
         {
-          dst_chain_id: 'chain-2',
-          dst_connection_id: 'connection-2',
-          dst_channel_id: 'channel-2',
-          sequence: 1,
-          in_progress: Bool.FALSE,
-          is_ordered: Bool.FALSE,
-          height: 100,
-          dst_port: 'transfer',
-          src_chain_id: 'chain-1',
-          src_connection_id: 'connection-1',
-          src_port: 'transfer',
-          src_channel_id: 'channel-1',
-          packet_data: 'e2RhdGE6IG51bGx9',
-          timeout_height: 0,
-          timeout_timestamp: 1731051545,
-          timeout_height_raw: '0-0',
-          timeout_timestamp_raw: '1731051545000000000',
+          key: 'channel_id',
+          value: 'channel-1',
         },
-      ]
-      expect(res).toEqual(expectVal)
-    }
+        {
+          key: 'packet_sequence',
+          value: '1',
+        },
+        {
+          key: 'recv_fee',
+          value: '100tokena,200tokenb',
+        },
+        {
+          key: 'ack_fee',
+          value: '200tokena,100tokenb',
+        },
+        {
+          key: 'timeout_fee',
+          value: '300tokena,300tokenb',
+        },
+        {
+          key: 'msg_index',
+          value: '0',
+        },
+      ],
+    })
+
+    // create feed functions
+    const fns = PacketFeeController.feedEvents(mockServer1.rest.chainId, [
+      event,
+    ])
+
+    // execute feed functions
+    fns()
+
+    // check db insertion
+    const res = select(DB, PacketFeeController.tableName)
+    const expectVal: PacketFeeTable[] = [
+      {
+        chain_id: mockServer1.rest.chainId,
+        channel_id: 'channel-1',
+        sequence: event.sequence,
+        fee_type: FeeType.RECV,
+        denom: 'tokena',
+        amount: 100,
+      },
+      {
+        chain_id: mockServer1.rest.chainId,
+        channel_id: 'channel-1',
+        sequence: event.sequence,
+        fee_type: FeeType.RECV,
+        denom: 'tokenb',
+        amount: 200,
+      },
+      {
+        chain_id: mockServer1.rest.chainId,
+        channel_id: 'channel-1',
+        sequence: event.sequence,
+        fee_type: FeeType.ACK,
+        denom: 'tokena',
+        amount: 200,
+      },
+      {
+        chain_id: mockServer1.rest.chainId,
+        channel_id: 'channel-1',
+        sequence: event.sequence,
+        fee_type: FeeType.ACK,
+        denom: 'tokenb',
+        amount: 100,
+      },
+      {
+        chain_id: mockServer1.rest.chainId,
+        channel_id: 'channel-1',
+        sequence: event.sequence,
+        fee_type: FeeType.TIMEOUT,
+        denom: 'tokena',
+        amount: 300,
+      },
+      {
+        chain_id: mockServer1.rest.chainId,
+        channel_id: 'channel-1',
+        sequence: event.sequence,
+        fee_type: FeeType.TIMEOUT,
+        denom: 'tokenb',
+        amount: 300,
+      },
+    ]
+    expect(res).toEqual(expectVal)
   })
 })

--- a/src/db/controller/packetFee.ts
+++ b/src/db/controller/packetFee.ts
@@ -26,7 +26,7 @@ export class PacketFeeController {
             denom: coin.denom,
             amount: Number(coin.amount),
           }
-          insert(DB, this.tableName, packetFee)
+          insert(DB, PacketFeeController.tableName, packetFee)
         }
       }
     }
@@ -52,7 +52,7 @@ export class PacketFeeController {
     sequence: number,
     type: FeeType
   ) {
-    del<PacketFeeTable>(DB, this.tableName, [
+    del<PacketFeeTable>(DB, PacketFeeController.tableName, [
       { chain_id: chainId, channel_id: channelId, sequence, fee_type: type },
     ])
   }

--- a/src/db/controller/syncInfo.ts
+++ b/src/db/controller/syncInfo.ts
@@ -25,7 +25,7 @@ export class SyncInfoController {
         synced_height: startHeight - 1,
       }
 
-      insert(DB, this.tableName, syncInfo)
+      insert(DB, SyncInfoController.tableName, syncInfo)
       syncInfos.unshift(syncInfo)
     }
 
@@ -41,7 +41,7 @@ export class SyncInfoController {
           }
 
           syncInfos.unshift(newSyncInfo)
-          insert(DB, this.tableName, newSyncInfo)
+          insert(DB, SyncInfoController.tableName, newSyncInfo)
         }
 
         // TODO: split sync info when syncInfo.syncedHeight < startHeight < syncInfo.endHeight
@@ -53,7 +53,9 @@ export class SyncInfoController {
   }
 
   public static getSyncInfos(chainId: string): SyncInfoTable[] {
-    return select<SyncInfoTable>(DB, this.tableName, [{ chain_id: chainId }])
+    return select<SyncInfoTable>(DB, SyncInfoController.tableName, [
+      { chain_id: chainId },
+    ])
   }
 
   /**
@@ -73,28 +75,38 @@ export class SyncInfoController {
   ): boolean {
     // check finish
     if (syncedHeight === endHeight) {
-      del(DB, this.tableName, [
+      del(DB, SyncInfoController.tableName, [
         { chain_id: chainId, start_height: startHeight },
       ])
 
-      update<SyncInfoTable>(DB, this.tableName, { start_height: startHeight }, [
-        {
-          chain_id: chainId,
-          start_height: endHeight + 1,
-        },
-      ])
+      update<SyncInfoTable>(
+        DB,
+        SyncInfoController.tableName,
+        { start_height: startHeight },
+        [
+          {
+            chain_id: chainId,
+            start_height: endHeight + 1,
+          },
+        ]
+      )
 
-      console.log(select(DB, this.tableName))
+      console.log(select(DB, SyncInfoController.tableName))
 
       return true
     }
 
-    update<SyncInfoTable>(DB, this.tableName, { synced_height: syncedHeight }, [
-      {
-        chain_id: chainId,
-        start_height: startHeight,
-      },
-    ])
+    update<SyncInfoTable>(
+      DB,
+      SyncInfoController.tableName,
+      { synced_height: syncedHeight },
+      [
+        {
+          chain_id: chainId,
+          start_height: startHeight,
+        },
+      ]
+    )
 
     return false
   }

--- a/src/lib/eventParser.spec.ts
+++ b/src/lib/eventParser.spec.ts
@@ -87,7 +87,7 @@ describe('event parser', () => {
         timeoutTimestamp: 1730467768,
         timeoutHeightRaw: '0-0',
         timeoutTimestampRaw: '1730467768229000000',
-        ordering: undefined,
+        ordering: '',
         ack: 'eyJyZXN1bHQiOiJBUT09In0=',
       }
 

--- a/src/lib/eventParser.ts
+++ b/src/lib/eventParser.ts
@@ -141,6 +141,14 @@ export function parseUpdateClientEvent(event: Event): UpdateClientEvent {
   }
 }
 
+// recover_client or upgrade_client
+export function parseReplaceClientEvent(event: Event): string {
+  const clientId =
+    find(event, 'subject_client_id') ?? (find(event, 'client_id"') as string)
+
+  return clientId
+}
+
 function getConnection(event: Event): string | undefined {
   return find(event, 'connection_id') || find(event, 'packet_connection')
 }

--- a/src/lib/eventParser.ts
+++ b/src/lib/eventParser.ts
@@ -1,5 +1,10 @@
 import { Event } from '@cosmjs/tendermint-rpc/build/comet38/responses'
-import { ChannelOpenCloseInfo, PacketFeeEvent, PacketInfo } from 'src/types'
+import {
+  ChannelOpenCloseInfo,
+  PacketFeeEvent,
+  PacketInfo,
+  UpdateClientEvent,
+} from 'src/types'
 
 export function parsePacketEvent(event: Event, height: number): PacketInfo {
   const connectionId = getConnection(event) as string
@@ -121,6 +126,18 @@ export function parsePacketFeeEvent(event: Event): PacketFeeEvent {
     recvFee,
     ackFee,
     timeoutFee,
+  }
+}
+
+export function parseUpdateClientEvent(event: Event): UpdateClientEvent {
+  const clientId = find(event, 'client_id') as string
+  const header = find(event, 'header') as string
+  const consensusHeights = find(event, 'consensus_heights') as string
+
+  return {
+    clientId,
+    header,
+    consensusHeights,
   }
 }
 

--- a/src/lib/eventParser.ts
+++ b/src/lib/eventParser.ts
@@ -144,7 +144,7 @@ export function parseUpdateClientEvent(event: Event): UpdateClientEvent {
 // recover_client or upgrade_client
 export function parseReplaceClientEvent(event: Event): string {
   const clientId =
-    find(event, 'subject_client_id') ?? (find(event, 'client_id"') as string)
+    find(event, 'subject_client_id') ?? (find(event, 'client_id') as string)
 
   return clientId
 }

--- a/src/lib/restClient.ts
+++ b/src/lib/restClient.ts
@@ -57,7 +57,8 @@ class IbcAPI extends IbcAPI_ {
 
   async lastConsensusState(clientId: string) {
     return this.c.get<ConsState>(
-      `/ibc/core/client/v1/consensus_states/${clientId}/revision/0/height/0?latest_height=true`
+      `/ibc/core/client/v1/consensus_states/${clientId}/revision/0/height/0`,
+      { latest_height: 'true' }
     )
   }
 

--- a/src/lib/restClient.ts
+++ b/src/lib/restClient.ts
@@ -55,6 +55,12 @@ class IbcAPI extends IbcAPI_ {
     )
   }
 
+  async lastConsensusState(clientId: string) {
+    return this.c.get<ConsState>(
+      `/ibc/core/client/v1/consensus_states/${clientId}/revision/0/height/0?latest_height=true`
+    )
+  }
+
   async getConnection(connectionId: string): Promise<ConnectionInfo> {
     return this.c.get<ConnectionInfo>(
       `/ibc/core/connection/v1/connections/${connectionId}`
@@ -97,6 +103,22 @@ interface ChannelResponseRaw {
 
 interface NextSequence {
   next_sequence_receive: string
+  proof: null | string
+  proof_height: {
+    revision_number: string
+    revision_height: string
+  }
+}
+
+interface ConsState {
+  consensus_state: {
+    '@type': string
+    timestamp: string
+    root: {
+      hash: string
+    }
+    next_validators_hash: string
+  }
   proof: null | string
   proof_height: {
     revision_number: string

--- a/src/msgs/updateClient.ts
+++ b/src/msgs/updateClient.ts
@@ -116,7 +116,8 @@ async function getValidatorSet(
 
   const proposer: Validator | undefined = mappedValidators.find(
     (val) =>
-      Buffer.from(val.address).toString('hex') === proposerAddress.toLowerCase()
+      Buffer.from(val.address).toString('hex').toLowerCase() ===
+      proposerAddress.toLowerCase()
   )
 
   return ValidatorSet.fromPartial({

--- a/src/msgs/updateClient.ts
+++ b/src/msgs/updateClient.ts
@@ -76,12 +76,10 @@ async function getValidatorSet(
   chain: ChainWorker,
   height: number
 ): Promise<ValidatorSet> {
-  let block = await chain.rest.tendermint
-    .blockInfo(height)
-    .catch(() => undefined)
+  let header = await chain.rpc.header(height).catch(() => undefined)
   let count = 0
-  while (block === undefined) {
-    block = await chain.rest.tendermint.blockInfo(height).catch((e) => {
+  while (header === undefined) {
+    header = await chain.rpc.header(height).catch((e) => {
       if (count > 5) {
         throw e
       }
@@ -90,7 +88,7 @@ async function getValidatorSet(
     await delay(100)
     count++
   }
-  const proposerAddress = block.block.header.proposer_address
+  const proposerAddress = header.header.proposer_address
   // we need to query the header to find out who the proposer was, and pull them out
   const validators = await chain.rpc.validatorsAll(height)
   let totalVotingPower = BigInt(0)
@@ -117,7 +115,8 @@ async function getValidatorSet(
   })
 
   const proposer: Validator | undefined = mappedValidators.find(
-    (val) => Buffer.from(val.address).toString('base64') === proposerAddress
+    (val) =>
+      Buffer.from(val.address).toString('hex') === proposerAddress.toLowerCase()
   )
 
   return ValidatorSet.fromPartial({

--- a/src/workers/chain.ts
+++ b/src/workers/chain.ts
@@ -11,6 +11,7 @@ import {
   parseChannelOpenEvent,
   parsePacketEvent,
   parsePacketFeeEvent,
+  parseReplaceClientEvent,
   parseUpdateClientEvent,
 } from 'src/lib/eventParser'
 import { DB } from 'src/db'
@@ -148,6 +149,9 @@ class SyncWorker {
         const updateClientEvents = events
           .map((e) => e.updateClientEvents)
           .flat()
+        const replaceClientEvents = events
+          .map((e) => e.replaceClientEvents)
+          .flat()
 
         this.logger.debug(
           `Fetched block results for heights (${JSON.stringify(heights)})`
@@ -159,6 +163,15 @@ class SyncWorker {
             this.chain.rest,
             this.chain.chainId,
             event
+          )
+        }
+
+        // `upgradeClient` and `recoverClient` does not need to be included in the db transaction
+        for (const clientId of replaceClientEvents) {
+          await ClientController.replaceClient(
+            this.chain.rest,
+            this.chain.chainId,
+            clientId
           )
         }
 
@@ -216,68 +229,83 @@ class SyncWorker {
     channelOpenEvents: ChannelOpenCloseEvent[]
     packetFeeEvents: PacketFeeEvent[]
     updateClientEvents: UpdateClientEvent[]
+    replaceClientEvents: string[]
   }> {
     this.logger.debug(`Fetch new block results (height - ${height})`)
     const blockResult = await this.chain.rpc.blockResults(height)
-    const txData = [...blockResult.results]
+
+    const events = [
+      // parse events from begin block
+      ...blockResult.beginBlockEvents,
+
+      // parse events from txs
+      ...blockResult.results.map((res) => res.events).flat(),
+
+      // parse events from end block
+      ...blockResult.endBlockEvents,
+    ]
 
     const packetEvents: PacketEvent[] = []
     const channelOpenEvents: ChannelOpenCloseEvent[] = []
     const packetFeeEvents: PacketFeeEvent[] = []
     const updateClientEvents: UpdateClientEvent[] = []
+    const replaceClientEvents: string[] = []
 
-    txData.map((data) => {
-      for (const event of data.events) {
-        if (
-          event.type === 'send_packet' ||
-          event.type === 'write_acknowledgement' ||
-          event.type === 'acknowledge_packet' ||
-          event.type === 'timeout_packet'
-        ) {
-          packetEvents.push({
-            type: event.type,
-            packetInfo: parsePacketEvent(event, height),
-          })
-        }
-
-        if (
-          event.type === 'channel_open_init' ||
-          event.type === 'channel_open_try' ||
-          event.type === 'channel_open_ack' ||
-          event.type === 'channel_open_confirm'
-        ) {
-          channelOpenEvents.push({
-            type: event.type,
-            channelOpenCloseInfo: parseChannelOpenEvent(event, height),
-          })
-        }
-
-        if (
-          event.type === 'channel_close_init' ||
-          event.type === 'channel_close' ||
-          event.type === 'channel_close_confirm'
-        ) {
-          channelOpenEvents.push({
-            type: event.type,
-            channelOpenCloseInfo: parseChannelCloseEvent(event, height),
-          })
-        }
-
-        if (event.type === 'incentivized_ibc_packet') {
-          packetFeeEvents.push(parsePacketFeeEvent(event))
-        }
-
-        if (event.type === 'update_client') {
-          updateClientEvents.push(parseUpdateClientEvent(event))
-        }
+    for (const event of events) {
+      if (
+        event.type === 'send_packet' ||
+        event.type === 'write_acknowledgement' ||
+        event.type === 'acknowledge_packet' ||
+        event.type === 'timeout_packet'
+      ) {
+        packetEvents.push({
+          type: event.type,
+          packetInfo: parsePacketEvent(event, height),
+        })
       }
-    })
+
+      if (
+        event.type === 'channel_open_init' ||
+        event.type === 'channel_open_try' ||
+        event.type === 'channel_open_ack' ||
+        event.type === 'channel_open_confirm'
+      ) {
+        channelOpenEvents.push({
+          type: event.type,
+          channelOpenCloseInfo: parseChannelOpenEvent(event, height),
+        })
+      }
+
+      if (
+        event.type === 'channel_close_init' ||
+        event.type === 'channel_close' ||
+        event.type === 'channel_close_confirm'
+      ) {
+        channelOpenEvents.push({
+          type: event.type,
+          channelOpenCloseInfo: parseChannelCloseEvent(event, height),
+        })
+      }
+
+      if (event.type === 'incentivized_ibc_packet') {
+        packetFeeEvents.push(parsePacketFeeEvent(event))
+      }
+
+      if (event.type === 'update_client') {
+        updateClientEvents.push(parseUpdateClientEvent(event))
+      }
+
+      if (event.type === 'upgrade_client' || event.type === 'recover_client') {
+        replaceClientEvents.push(parseReplaceClientEvent(event))
+      }
+    }
 
     return {
       packetEvents,
       channelOpenEvents,
       packetFeeEvents,
       updateClientEvents,
+      replaceClientEvents,
     }
   }
 }

--- a/src/workers/wallet.ts
+++ b/src/workers/wallet.ts
@@ -101,13 +101,11 @@ export class WalletWorker {
             feeFilter,
             this.packetFilter,
             remain
-          ).filter((packet) => {
-            console.log(packet)
-            return (
+          ).filter(
+            (packet) =>
               packet.height <
               this.workerController.chains[packet.dst_chain_id].latestHeight
-            )
-          })
+          )
 
     remain -= writeAckPackets.length
 

--- a/src/workers/wallet.ts
+++ b/src/workers/wallet.ts
@@ -306,7 +306,9 @@ export class WalletWorker {
         filteredChannelOpenCloseEvents
           .sort((a, b) => b.state - a.state) // to make execute close first
           .filter(
-            (event) => connectionClientMap[event.connection_id] !== undefined
+            (event) =>
+              updateClientMsgs[connectionClientMap[event.connection_id]] !==
+              undefined
           ) // filter expired client
           .map((event) => {
             const clientId = connectionClientMap[event.connection_id]

--- a/src/workers/wallet.ts
+++ b/src/workers/wallet.ts
@@ -212,7 +212,7 @@ export class WalletWorker {
         )
 
         return (
-          client.last_update_time + client.trusting_period < currentTimestamp
+          client.last_update_time + client.trusting_period > currentTimestamp
         )
       }
 

--- a/src/workers/wallet.ts
+++ b/src/workers/wallet.ts
@@ -101,11 +101,13 @@ export class WalletWorker {
             feeFilter,
             this.packetFilter,
             remain
-          ).filter(
-            (packet) =>
+          ).filter((packet) => {
+            console.log(packet)
+            return (
               packet.height <
               this.workerController.chains[packet.dst_chain_id].latestHeight
-          )
+            )
+          })
 
     remain -= writeAckPackets.length
 
@@ -243,7 +245,9 @@ export class WalletWorker {
         filteredSendPackets
           .filter(
             (packet) =>
-              connectionClientMap[packet.dst_connection_id] !== undefined
+              updateClientMsgs[
+                connectionClientMap[packet.dst_connection_id]
+              ] !== undefined
           ) // filter expired client
           .map((packet) => {
             const clientId = connectionClientMap[packet.dst_connection_id]
@@ -262,7 +266,9 @@ export class WalletWorker {
         filteredWriteAckPackets
           .filter(
             (packet) =>
-              connectionClientMap[packet.src_connection_id] !== undefined
+              updateClientMsgs[
+                connectionClientMap[packet.src_connection_id]
+              ] !== undefined
           ) // filter expired client
           .map((packet) => {
             const clientId = connectionClientMap[packet.src_connection_id]
@@ -281,7 +287,9 @@ export class WalletWorker {
         filteredTimeoutPackets
           .filter(
             (packet) =>
-              connectionClientMap[packet.src_connection_id] !== undefined
+              updateClientMsgs[
+                connectionClientMap[packet.src_connection_id]
+              ] !== undefined
           ) // filter expired client
           .map((packet) => {
             const clientId = connectionClientMap[packet.src_connection_id]

--- a/src/workers/wallet.ts
+++ b/src/workers/wallet.ts
@@ -202,7 +202,7 @@ export class WalletWorker {
       ]
 
       // check client expiration
-      const fileterExpiredClient = async (clientId: string) => {
+      const filterExpiredClient = async (clientId: string) => {
         const currentTimestamp = new Date().valueOf() / 1000
 
         const client = await ClientController.getClient(
@@ -218,7 +218,7 @@ export class WalletWorker {
 
       const filteredClientIds = await asyncFilter(
         clientIds,
-        fileterExpiredClient
+        filterExpiredClient
       )
 
       // generate msgs


### PR DESCRIPTION
Features
- Client Expiration Prevention:
  - Update the client immediately after two-thirds of the trust period has passed.
  - Parse and feed the update client event.
  - Fix the `feedUpdateClientEvent` function.
 
Improvements
  - Query Optimization:
    - Use `rpc.header` instead of `rest.block_info` to reduce query costs and avoid the `grpc: received message larger than max` error.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced a new method for retrieving clients that require updates.
	- Added functionality to handle `UpdateClientEvent` in event processing.
	- Implemented new event parsing functions for client updates.
	- Added a new function to categorize events based on attributes in block results.
	- Added a method to retrieve the latest consensus state for a given client ID.

- **Bug Fixes**
	- Enhanced error handling and address matching logic in the `getValidatorSet` function.

- **Tests**
	- Added a new test suite for the `ClientController` functionality.
	- Updated test cases for the `parsePacketEvent` function to align with new specifications.
	- Restructured test cases to focus on packet sending and fee processing.

- **Chores**
	- Refactored references to table names for consistency across various controllers.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->