### PR TITLE
fix: update pk for packet_timeout and packet_write_ack

### DIFF
--- a/src/db/migration/0.0.3.sql
+++ b/src/db/migration/0.0.3.sql
@@ -1,3 +1,6 @@
+-- update version
+UPDATE version set version = '0.0.3' WHERE id == 1;
+
 -- Update pk
 
 -- Create the new table with updated primary key

--- a/src/db/migration/0.0.4.sql
+++ b/src/db/migration/0.0.4.sql
@@ -1,3 +1,6 @@
+-- update version
+UPDATE version set version = '0.0.4' WHERE id == 1;
+
 -- Update pk
 
 -- Create the new table with updated primary key

--- a/src/db/migration/0.0.4.sql
+++ b/src/db/migration/0.0.4.sql
@@ -1,0 +1,69 @@
+-- Update pk
+
+-- Create the new table with updated primary key
+
+-- packet timeout
+CREATE TABLE packet_timeout_new (
+    src_chain_id TEXT NOT NULL,
+    src_channel_id TEXT NOT NULL,
+    sequence BIGINT NOT NULL,
+    in_progress BOOLEAN,
+    is_ordered BOOLEAN,
+    src_connection_id TEXT NOT NULL,
+    src_port TEXT NOT NULL,
+    dst_chain_id TEXT NOT NULL,
+    dst_connection_id TEXT NOT NULL,
+    dst_port TEXT NOT NULL,
+    dst_channel_id TEXT NOT NULL,
+    packet_data TEXT NOT NULL,
+    timeout_height BIGINT NOT NULL,
+    timeout_timestamp BIGINT NOT NULL,
+    timeout_height_raw TEXT NOT NULL,
+    timeout_timestamp_raw TEXT NOT NULL,
+
+    PRIMARY KEY (src_chain_id, src_channel_id, dst_channel_id, sequence)
+);
+
+-- Copy data from old table
+INSERT INTO packet_timeout_new
+SELECT * FROM packet_timeout;
+
+-- Drop the old table
+DROP TABLE packet_timeout;
+
+-- Rename new table to original name
+ALTER TABLE packet_timeout_new RENAME TO packet_timeout;
+
+-- ack
+CREATE TABLE packet_write_ack_new (
+    src_chain_id TEXT NOT NULL,
+    src_channel_id TEXT NOT NULL,
+    sequence BIGINT NOT NULL,
+    in_progress BOOLEAN,
+    is_ordered BOOLEAN,
+    height BIGINT NOT NULL,
+    src_connection_id TEXT NOT NULL,
+    src_port TEXT NOT NULL,
+    dst_chain_id TEXT NOT NULL,
+    dst_connection_id TEXT NOT NULL,
+    dst_port TEXT NOT NULL,
+    dst_channel_id TEXT NOT NULL,
+    packet_data TEXT NOT NULL,
+    ack TEXT NOT NULL,
+    timeout_height BIGINT NOT NULL,
+    timeout_timestamp BIGINT NOT NULL,
+    timeout_height_raw TEXT NOT NULL,
+    timeout_timestamp_raw TEXT NOT NULL,
+
+    PRIMARY KEY (src_chain_id, src_channel_id, dst_channel_id, sequence)
+);
+
+-- Copy data from old table
+INSERT INTO packet_write_ack_new
+SELECT * FROM packet_write_ack;
+
+-- Drop the old table
+DROP TABLE packet_write_ack;
+
+-- Rename new table to original name
+ALTER TABLE packet_write_ack_new RENAME TO packet_write_ack;


### PR DESCRIPTION
To prevent `UNIQUE constraint failed` error add dst_channel_id to `packet_timeout` table and `packet_write_ack` table

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
  - Updated the database schema to improve primary key structure for certain tables, ensuring better data integrity and consistency. Data has been preserved during this update.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->