### PR TITLE
fix: use `dst_chain.latestHeight` for timeout height

### DIFF
--- a/src/db/controller/packet.spec.ts
+++ b/src/db/controller/packet.spec.ts
@@ -1,10 +1,15 @@
-import { Bool, PacketEvent, PacketSendTable } from 'src/types'
+import {
+  Bool,
+  PacketEvent,
+  PacketSendTable,
+  PacketTimeoutTable,
+} from 'src/types'
 import { DB } from '..'
 import { select } from '../utils'
 import { PacketController } from './packet'
 import { mockServers } from 'src/test/testSetup'
 
-describe('channel controler', () => {
+describe('packet controller', () => {
   test('packet send e2e', async () => {
     const [mockServer1] = mockServers
     // test send_packet
@@ -22,9 +27,9 @@ describe('channel controler', () => {
             dstPort: 'transfer',
             data: 'e2RhdGE6IG51bGx9',
             dstChannel: 'channel-2',
-            timeoutHeight: 0,
+            timeoutHeight: 1234,
             timeoutTimestamp: 1731051545,
-            timeoutHeightRaw: '0-0',
+            timeoutHeightRaw: '0-1234',
             timeoutTimestampRaw: '1731051545000000000',
           },
         },
@@ -57,14 +62,175 @@ describe('channel controler', () => {
           src_port: 'transfer',
           src_channel_id: 'channel-1',
           packet_data: 'e2RhdGE6IG51bGx9',
-          timeout_height: 0,
+          timeout_height: 1234,
           timeout_timestamp: 1731051545,
-          timeout_height_raw: '0-0',
+          timeout_height_raw: '0-1234',
           timeout_timestamp_raw: '1731051545000000000',
         },
       ]
 
       expect(res).toEqual(expectVal)
+    }
+
+    // test getSendPackets
+
+    {
+      const expectVal: PacketSendTable[] = [
+        {
+          dst_chain_id: 'chain-2',
+          dst_connection_id: 'connection-2',
+          dst_channel_id: 'channel-2',
+          sequence: 1,
+          in_progress: Bool.FALSE,
+          is_ordered: Bool.FALSE,
+          height: 100,
+          dst_port: 'transfer',
+          src_chain_id: 'chain-1',
+          src_connection_id: 'connection-1',
+          src_port: 'transfer',
+          src_channel_id: 'channel-1',
+          packet_data: 'e2RhdGE6IG51bGx9',
+          timeout_height: 1234,
+          timeout_timestamp: 1731051545,
+          timeout_height_raw: '0-1234',
+          timeout_timestamp_raw: '1731051545000000000',
+        },
+      ]
+
+      const bothWithinTimeout = PacketController.getSendPackets(
+        'chain-2',
+        1233,
+        1731051544,
+        [
+          {
+            chainId: 'chain-1',
+            feeFilter: {},
+            latestHeight: 1,
+          },
+        ]
+      )
+
+      const heightTimeout = PacketController.getSendPackets(
+        'chain-2',
+        1235,
+        1731051544,
+        [
+          {
+            chainId: 'chain-1',
+            feeFilter: {},
+            latestHeight: 1,
+          },
+        ]
+      )
+
+      const timestampTimeout = PacketController.getSendPackets(
+        'chain-2',
+        1233,
+        1731051547,
+        [
+          {
+            chainId: 'chain-1',
+            feeFilter: {},
+            latestHeight: 1,
+          },
+        ]
+      )
+
+      const bothTimeout = PacketController.getSendPackets(
+        'chain-2',
+        1235,
+        1731051547,
+        [
+          {
+            chainId: 'chain-1',
+            feeFilter: {},
+            latestHeight: 1,
+          },
+        ]
+      )
+
+      expect(bothWithinTimeout).toEqual(expectVal)
+      expect(heightTimeout).toEqual([])
+      expect(timestampTimeout).toEqual([])
+      expect(bothTimeout).toEqual([])
+    }
+
+    // test getTimeoutPackets
+
+    {
+      const expectVal: PacketTimeoutTable[] = [
+        {
+          dst_chain_id: 'chain-2',
+          dst_connection_id: 'connection-2',
+          dst_channel_id: 'channel-2',
+          sequence: 1,
+          in_progress: Bool.FALSE,
+          is_ordered: Bool.FALSE,
+          dst_port: 'transfer',
+          src_chain_id: 'chain-1',
+          src_connection_id: 'connection-1',
+          src_port: 'transfer',
+          src_channel_id: 'channel-1',
+          packet_data: 'e2RhdGE6IG51bGx9',
+          timeout_height: 1234,
+          timeout_timestamp: 1731051545,
+          timeout_height_raw: '0-1234',
+          timeout_timestamp_raw: '1731051545000000000',
+        },
+      ]
+
+      const bothWithinTimeout = PacketController.getTimeoutPackets(
+        'chain-1',
+        1731051544,
+        [
+          {
+            chainId: 'chain-2',
+            feeFilter: {},
+            latestHeight: 1233,
+          },
+        ]
+      )
+
+      const heightTimeout = PacketController.getTimeoutPackets(
+        'chain-1',
+        1731051544,
+        [
+          {
+            chainId: 'chain-2',
+            feeFilter: {},
+            latestHeight: 1235,
+          },
+        ]
+      )
+
+      const timestampTimeout = PacketController.getTimeoutPackets(
+        'chain-1',
+        1731051547,
+        [
+          {
+            chainId: 'chain-2',
+            feeFilter: {},
+            latestHeight: 1233,
+          },
+        ]
+      )
+
+      const bothTimeout = PacketController.getTimeoutPackets(
+        'chain-1',
+        1731051547,
+        [
+          {
+            chainId: 'chain-2',
+            feeFilter: {},
+            latestHeight: 1235,
+          },
+        ]
+      )
+
+      expect(bothWithinTimeout).toEqual([])
+      expect(heightTimeout).toEqual(expectVal)
+      expect(timestampTimeout).toEqual(expectVal)
+      expect(bothTimeout).toEqual(expectVal)
     }
   })
 })

--- a/src/db/controller/packet.ts
+++ b/src/db/controller/packet.ts
@@ -59,6 +59,7 @@ export class PacketController {
 
   public static getSendPackets(
     chainId: string,
+    height: number,
     timestamp: number,
     chainIdsWithFeeFilters: ChainFilterInfo[],
     filter: PacketFilter = {},
@@ -70,12 +71,11 @@ export class PacketController {
       for (const {
         chainId: counterpartyChainId,
         feeFilter,
-        latestHeight,
       } of chainIdsWithFeeFilters) {
         const wheres: WhereOptions<PacketSendTable>[] =
           PacketController.getSendPacketsWhere(
             chainId,
-            Number(latestHeight),
+            height,
             timestamp,
             counterpartyChainId,
             feeFilter,
@@ -111,6 +111,7 @@ export class PacketController {
 
   public static getSendPacketsCount(
     chainId: string,
+    height: number,
     timestamp: number,
     chainIdsWithFeeFilters: ChainFilterInfo[],
     filter: PacketFilter = {}
@@ -120,12 +121,11 @@ export class PacketController {
     for (const {
       chainId: counterpartyChainId,
       feeFilter,
-      latestHeight,
     } of chainIdsWithFeeFilters) {
       const wheres: WhereOptions<PacketSendTable>[] =
         PacketController.getSendPacketsWhere(
           chainId,
-          latestHeight,
+          height,
           timestamp,
           counterpartyChainId,
           feeFilter,
@@ -200,8 +200,8 @@ export class PacketController {
     } of chainIdsWithFeeFilters) {
       const wheres = PacketController.getTimeoutPacketsWhere(
         chainId,
-        timestamp,
         latestHeight,
+        timestamp,
         counterpartyChainId,
         feeFilter,
         filter

--- a/src/db/controller/packet.ts
+++ b/src/db/controller/packet.ts
@@ -59,9 +59,8 @@ export class PacketController {
 
   public static getSendPackets(
     chainId: string,
-    height: number,
     timestamp: number,
-    chainIdsWithFeeFilters: { chainId: string; feeFilter: PacketFee }[],
+    chainIdsWithFeeFilters: ChainFilterInfo[],
     filter: PacketFilter = {},
     limit = 100
   ): PacketSendTable[] {
@@ -71,11 +70,12 @@ export class PacketController {
       for (const {
         chainId: counterpartyChainId,
         feeFilter,
+        latestHeight,
       } of chainIdsWithFeeFilters) {
         const wheres: WhereOptions<PacketSendTable>[] =
           PacketController.getSendPacketsWhere(
             chainId,
-            height,
+            Number(latestHeight),
             timestamp,
             counterpartyChainId,
             feeFilter,
@@ -111,9 +111,8 @@ export class PacketController {
 
   public static getSendPacketsCount(
     chainId: string,
-    height: number,
     timestamp: number,
-    chainIdsWithFeeFilters: { chainId: string; feeFilter: PacketFee }[],
+    chainIdsWithFeeFilters: ChainFilterInfo[],
     filter: PacketFilter = {}
   ): number {
     let packetCount = 0
@@ -121,11 +120,12 @@ export class PacketController {
     for (const {
       chainId: counterpartyChainId,
       feeFilter,
+      latestHeight,
     } of chainIdsWithFeeFilters) {
       const wheres: WhereOptions<PacketSendTable>[] =
         PacketController.getSendPacketsWhere(
           chainId,
-          height,
+          latestHeight,
           timestamp,
           counterpartyChainId,
           feeFilter,
@@ -151,7 +151,7 @@ export class PacketController {
     filter: PacketFilter = {}
   ): WhereOptions<PacketSendTable>[] {
     const wheres: WhereOptions<PacketSendTable>[] = []
-    let custom = `(timeout_height > ${height} OR timeout_timestamp > ${timestamp})` // filter timeout packet
+    let custom = `((timeout_height = 0 OR timeout_height > ${height}) AND (timeout_timestamp = 0 OR timeout_timestamp > ${timestamp}))` // filter timeout packet
     if (feeFilter.recvFee && feeFilter.recvFee.length !== 0) {
       const conditions = feeFilter.recvFee.map(
         (v) =>
@@ -186,64 +186,82 @@ export class PacketController {
 
   public static getTimeoutPackets(
     chainId: string,
-    height: number,
     timestamp: number,
-    counterpartyChainIds: string[],
-    feeFilter: PacketFee,
+    chainIdsWithFeeFilters: ChainFilterInfo[],
     filter: PacketFilter = {},
     limit = 100
   ): PacketTimeoutTable[] {
-    const wheres = PacketController.getTimeoutPacketsWhere(
-      chainId,
-      height,
-      timestamp,
-      counterpartyChainIds,
-      feeFilter,
-      filter
-    )
+    const res: PacketTimeoutTable[] = []
 
-    return select<PacketTimeoutTable>(
-      DB,
-      PacketController.tableNamePacketTimeout,
-      wheres,
-      { sequence: 'ASC' },
-      limit
-    )
+    for (const {
+      chainId: counterpartyChainId,
+      feeFilter,
+      latestHeight,
+    } of chainIdsWithFeeFilters) {
+      const wheres = PacketController.getTimeoutPacketsWhere(
+        chainId,
+        timestamp,
+        latestHeight,
+        counterpartyChainId,
+        feeFilter,
+        filter
+      )
+
+      res.push(
+        ...select<PacketTimeoutTable>(
+          DB,
+          PacketController.tableNamePacketTimeout,
+          wheres,
+          { sequence: 'ASC' },
+          limit
+        )
+      )
+    }
+
+    return res
   }
 
   public static getTimeoutPacketsCount(
     chainId: string,
-    height: number,
     timestamp: number,
-    counterpartyChainIds: string[],
-    feeFilter: PacketFee,
+    chainIdsWithFeeFilters: ChainFilterInfo[],
     filter: PacketFilter = {}
   ): number {
-    const wheres = PacketController.getTimeoutPacketsWhere(
-      chainId,
-      height,
-      timestamp,
-      counterpartyChainIds,
-      feeFilter,
-      filter
-    )
+    let timeoutCount = 0
 
-    return count<PacketTimeoutTable>(
-      DB,
-      PacketController.tableNamePacketTimeout,
-      wheres
-    )
+    for (const {
+      chainId: counterpartyChainId,
+      feeFilter,
+      latestHeight,
+    } of chainIdsWithFeeFilters) {
+      const wheres = PacketController.getTimeoutPacketsWhere(
+        chainId,
+        timestamp,
+        latestHeight,
+        counterpartyChainId,
+        feeFilter,
+        filter
+      )
+
+      timeoutCount += count<PacketTimeoutTable>(
+        DB,
+        PacketController.tableNamePacketTimeout,
+        wheres
+      )
+    }
+
+    return timeoutCount
   }
 
   private static getTimeoutPacketsWhere(
     chainId: string,
     height: number,
     timestamp: number,
-    counterpartyChainIds: string[],
+    counterpartyChainId: string,
     feeFilter: PacketFee,
     filter: PacketFilter = {}
   ): WhereOptions<PacketSendTable>[] {
-    let custom = `((timeout_height < ${height} AND timeout_height != 0) OR timeout_timestamp < ${timestamp} AND timeout_timestamp != 0)` // filter timeout packet
+    let custom = `((timeout_height < ${height} AND timeout_height != 0) OR (timeout_timestamp < ${timestamp} AND timeout_timestamp != 0))` // filter timeout packet
 
     if (feeFilter.timeoutFee && feeFilter.timeoutFee.length !== 0) {
       const conditions = feeFilter.timeoutFee.map(
@@ -263,7 +281,7 @@ export class PacketController {
           src_chain_id: chainId,
           src_connection_id: conn.connectionId,
           src_channel_id: conn.channels ? In(conn.channels) : undefined,
-          dst_chain_id: In(counterpartyChainIds),
+          dst_chain_id: counterpartyChainId,
           custom,
         }))
       )
@@ -271,7 +289,7 @@ export class PacketController {
       wheres.push({
         in_progress: Bool.FALSE,
         src_chain_id: chainId,
-        dst_chain_id: In(counterpartyChainIds),
+        dst_chain_id: counterpartyChainId,
         custom,
       })
     }
@@ -779,4 +797,10 @@ export interface PacketFilter {
     connectionId: string
     channels?: string[] // if empty search all
   }[] // if empty search all
+}
+
+export interface ChainFilterInfo {
+  chainId: string
+  feeFilter: PacketFee
+  latestHeight: number
 }

--- a/src/db/controller/packet.ts
+++ b/src/db/controller/packet.ts
@@ -236,8 +236,8 @@ export class PacketController {
     } of chainIdsWithFeeFilters) {
       const wheres = PacketController.getTimeoutPacketsWhere(
         chainId,
-        timestamp,
         latestHeight,
+        timestamp,
         counterpartyChainId,
         feeFilter,
         filter

--- a/src/workers/index.ts
+++ b/src/workers/index.ts
@@ -118,11 +118,16 @@ export class WorkerController {
     }
   }
 
-  public getFeeFilters(): { chainId: string; feeFilter: PacketFee }[] {
+  public getFeeFilters(): {
+    chainId: string
+    feeFilter: PacketFee
+    latestHeight: number
+  }[] {
     return Object.entries(this.chains).map(([chainId, chain]) => {
       return {
         chainId,
         feeFilter: chain.feeFilter,
+        latestHeight: chain.latestHeight,
       }
     })
   }

--- a/src/workers/wallet.ts
+++ b/src/workers/wallet.ts
@@ -102,7 +102,6 @@ export class WalletWorker {
 
     const sendPackets = PacketController.getSendPackets(
       this.chain.chainId,
-      this.chain.latestHeight,
       Number((this.chain.latestTimestamp / 1000).toFixed()),
       counterpartyChainIdsWithFeeFilter,
       this.packetFilter,
@@ -137,10 +136,8 @@ export class WalletWorker {
         ? []
         : PacketController.getTimeoutPackets(
             this.chain.chainId,
-            this.chain.latestHeight,
             Number((this.chain.latestTimestamp / 1000).toFixed()),
-            counterpartyChainIds,
-            feeFilter,
+            counterpartyChainIdsWithFeeFilter,
             this.packetFilter,
             remain
           )
@@ -477,7 +474,6 @@ export class WalletWorker {
     let count = 0
     count += PacketController.getSendPacketsCount(
       this.chain.chainId,
-      this.chain.latestHeight,
       Number((this.chain.latestTimestamp / 1000).toFixed()),
       counterpartyChainIdsWithFeeFilter,
       this.packetFilter
@@ -492,10 +488,8 @@ export class WalletWorker {
 
     count += PacketController.getTimeoutPacketsCount(
       this.chain.chainId,
-      this.chain.latestHeight,
       Number((this.chain.latestTimestamp / 1000).toFixed()),
-      counterpartyChainIds,
-      feeFilter,
+      counterpartyChainIdsWithFeeFilter,
       this.packetFilter
     )
 

--- a/src/workers/wallet.ts
+++ b/src/workers/wallet.ts
@@ -102,6 +102,7 @@ export class WalletWorker {
 
     const sendPackets = PacketController.getSendPackets(
       this.chain.chainId,
+      this.chain.latestHeight,
       Number((this.chain.latestTimestamp / 1000).toFixed()),
       counterpartyChainIdsWithFeeFilter,
       this.packetFilter,
@@ -474,6 +475,7 @@ export class WalletWorker {
     let count = 0
     count += PacketController.getSendPacketsCount(
       this.chain.chainId,
+      this.chain.latestHeight,
       Number((this.chain.latestTimestamp / 1000).toFixed()),
       counterpartyChainIdsWithFeeFilter,
       this.packetFilter


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Enhanced packet filtering by supporting additional chain information, allowing more precise selection based on latest block height.

* **Bug Fixes**
  * Improved timeout packet logic to ensure accurate filtering based on both height and timestamp conditions.

* **Tests**
  * Added comprehensive tests for packet filtering and timeout scenarios to verify correct behavior under various conditions.

* **Chores**
  * Updated internal methods and data structures to support richer filter information for packets.
  * Extended fee filter data to include latest block height for better packet processing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->