### PR TITLE
feat(chart): modify charts for metric annotations

### DIFF
--- a/charts/templates/statefulset.yaml
+++ b/charts/templates/statefulset.yaml
@@ -24,6 +24,10 @@ spec:
     metadata:
       labels:
         app: {{ quote .Release.Name }}
+      {{- if .Values.podAnnotations }}
+      annotations:
+        {{- toYaml .Values.podAnnotations  | nindent 8 }}
+      {{- end }}      
     spec:
       {{- if .Values.imagePullSecret }}
       imagePullSecrets:

--- a/charts/values.yaml
+++ b/charts/values.yaml
@@ -19,3 +19,5 @@ storage:
   requests: 10Gi
 
 annotations: {}
+
+podAnnotations: {}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for pod-level annotations in StatefulSet pods via a new podAnnotations value. This lets you attach metadata (e.g., sidecar injection, monitoring, scheduling hints) directly to pods without modifying existing chart-wide annotations.
  * Introduced a default empty podAnnotations entry in values to make configuration straightforward while remaining backward compatible.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->