### PR TITLE
feat: support multiple REST URIs

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,7 +90,10 @@ Create a `config.json` file with the following structure:
       "bech32Prefix": "init",
       "chainId": "chain-2",
       "gasPrice": "0umin",
-      "restUri": "https://rest.chain-2.com",
+      "restUri": [
+        "https://rest.chain-2.com",
+        "https://rest.chain-2.com/fallback"
+      ],
       "rpcUri": ["https://rpc.chain-2.com", "https://rpc.chain-2.com/fallback"],
       "wallets": [
         {
@@ -129,7 +132,7 @@ You can configure chains in two ways:
    - `CHAIN_<index>_CHAIN_ID`: Chain ID for the chain at index `<index>`
    - `CHAIN_<index>_BECH32_PREFIX`: Bech32 prefix for the chain
    - `CHAIN_<index>_GAS_PRICE`: Gas price for the chain
-   - `CHAIN_<index>_REST_URI`: REST URI for the chain
+   - `CHAIN_<index>_REST_URI`: REST URI for the chain (can be a single URI string or JSON array of URI strings)
    - `CHAIN_<index>_RPC_URI`: RPC URI for the chain (can be a single URI string or array of URI strings)
    - `CHAIN_<index>_FEE_FILTER`: JSON string containing the fee filter configuration
 
@@ -182,7 +185,7 @@ export CHAIN_0_FEE_FILTER='{"recvFee":[{"denom":"gas","amount":100}],"timeoutFee
 export CHAIN_1_CHAIN_ID=chain-2
 export CHAIN_1_BECH32_PREFIX=init
 export CHAIN_1_GAS_PRICE=0umin
-export CHAIN_1_REST_URI=https://rest.chain-2.com
+export CHAIN_1_REST_URI='["https://rest.chain-2.com", "https://rest-fallback.chain-2.com"]'  # JSON array of URI strings for fallback
 export CHAIN_1_RPC_URI='["https://rpc.chain-2.com", "https://rpc-fallback.chain-2.com"]'  # JSON array of URI strings for fallback
 
 # Chain 2 wallet 1 configuration

--- a/config.example.json
+++ b/config.example.json
@@ -50,7 +50,10 @@
       "bech32Prefix": "init",
       "chainId": "chain-2",
       "gasPrice": "0umin",
-      "restUri": "https://rest.chain-2.com",
+      "restUri": [
+        "https://rest.chain-2.com",
+        "https://rest.chain-2.com/fallback"
+      ],
       "rpcUri": "https://rpc.chain-2.com",
       "wallets": [
         {

--- a/config.schema.json
+++ b/config.schema.json
@@ -121,8 +121,18 @@
             "description": "gas price in format 0.1denom"
           },
           "restUri": {
-            "type": "string",
-            "description": "cosmos rest api uri"
+            "description": "cosmos rest api uri",
+            "oneOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "array",
+                "items": {
+                  "type": "string"
+                }
+              }
+            ]
           },
           "rpcUri": {
             "description": "cosmos rest rpc uri",

--- a/src/lib/config.spec.ts
+++ b/src/lib/config.spec.ts
@@ -170,6 +170,26 @@ describe('Configuration Loading', () => {
       ])
     })
 
+    it('should parse REST URI as array when formatted as JSON array', () => {
+      process.env.CHAIN_1_CHAIN_ID = 'test-chain-1'
+      process.env.CHAIN_1_BECH32_PREFIX = 'test'
+      process.env.CHAIN_1_GAS_PRICE = '0.01'
+      process.env.CHAIN_1_REST_URI =
+        '["http://localhost:1317", "http://localhost:1318"]'
+      process.env.CHAIN_1_RPC_URI = 'http://localhost:26657'
+
+      // Setup wallet env vars
+      process.env.CHAIN_1_WALLET_1_KEY_TYPE = 'raw'
+      process.env.CHAIN_1_WALLET_1_KEY_PRIVATE_KEY = 'testkey'
+
+      const config = loadEnvConfig()
+
+      expect(config.chains?.[0].restUri).toEqual([
+        'http://localhost:1317',
+        'http://localhost:1318',
+      ])
+    })
+
     it('should parse fee filter from env vars', () => {
       const feeFilter: PacketFee = {
         recvFee: [{ denom: 'token', amount: 100 }],

--- a/src/lib/config.spec.ts
+++ b/src/lib/config.spec.ts
@@ -190,6 +190,23 @@ describe('Configuration Loading', () => {
       ])
     })
 
+    it.each(['["http://localhost:1317",]', '[]', '[""]', '[123]'])(
+      'should reject invalid URI arrays: %s',
+      (uriArray) => {
+        process.env.CHAIN_1_CHAIN_ID = 'test-chain-1'
+        process.env.CHAIN_1_BECH32_PREFIX = 'test'
+        process.env.CHAIN_1_GAS_PRICE = '0.01'
+        process.env.CHAIN_1_REST_URI = uriArray
+        process.env.CHAIN_1_RPC_URI = 'http://localhost:26657'
+
+        // Setup wallet env vars
+        process.env.CHAIN_1_WALLET_1_KEY_TYPE = 'raw'
+        process.env.CHAIN_1_WALLET_1_KEY_PRIVATE_KEY = 'testkey'
+
+        expect(() => loadEnvConfig()).toThrow(/URI array/)
+      }
+    )
+
     it('should parse fee filter from env vars', () => {
       const feeFilter: PacketFee = {
         recvFee: [{ denom: 'token', amount: 100 }],

--- a/src/lib/config.ts
+++ b/src/lib/config.ts
@@ -35,7 +35,22 @@ const parseUriConfig = (rawUri: string): string | string[] => {
   const trimmedUri = rawUri.trim()
 
   if (trimmedUri.startsWith('[') && trimmedUri.endsWith(']')) {
-    return safeJsonParse<string[]>(trimmedUri, [trimmedUri])
+    let parsed: unknown
+    try {
+      parsed = JSON.parse(trimmedUri)
+    } catch (err) {
+      throw new Error(`Invalid URI array JSON: ${err}`)
+    }
+
+    if (
+      !Array.isArray(parsed) ||
+      parsed.length === 0 ||
+      parsed.some((uri) => typeof uri !== 'string' || uri.trim() === '')
+    ) {
+      throw new Error('URI array must contain at least one non-empty string')
+    }
+
+    return parsed.map((uri) => uri.trim())
   }
 
   return trimmedUri

--- a/src/lib/config.ts
+++ b/src/lib/config.ts
@@ -31,6 +31,16 @@ export const safeJsonParse = <T>(json: string, defaultValue: T): T => {
   }
 }
 
+const parseUriConfig = (rawUri: string): string | string[] => {
+  const trimmedUri = rawUri.trim()
+
+  if (trimmedUri.startsWith('[') && trimmedUri.endsWith(']')) {
+    return safeJsonParse<string[]>(trimmedUri, [trimmedUri])
+  }
+
+  return trimmedUri
+}
+
 // load configuration from environment variables
 export const loadEnvConfig = (): Partial<Config> => {
   const envConfig: Partial<Config> = {}
@@ -79,16 +89,15 @@ export const loadEnvConfig = (): Partial<Config> => {
         chain.bech32Prefix = env[`CHAIN_${index}_BECH32_PREFIX`]
       if (env[`CHAIN_${index}_GAS_PRICE`])
         chain.gasPrice = env[`CHAIN_${index}_GAS_PRICE`]
-      if (env[`CHAIN_${index}_REST_URI`])
-        chain.restUri = env[`CHAIN_${index}_REST_URI`]
+
+      const rawRestUri = env[`CHAIN_${index}_REST_URI`]?.trim()
+      if (rawRestUri) {
+        chain.restUri = parseUriConfig(rawRestUri)
+      }
 
       const rawRpcUri = env[`CHAIN_${index}_RPC_URI`]?.trim()
       if (rawRpcUri) {
-        if (rawRpcUri.startsWith('[') && rawRpcUri.endsWith(']')) {
-          chain.rpcUri = safeJsonParse<string[]>(rawRpcUri, [rawRpcUri])
-        } else {
-          chain.rpcUri = rawRpcUri
-        }
+        chain.rpcUri = parseUriConfig(rawRpcUri)
       }
 
       // fee filter
@@ -331,7 +340,7 @@ interface ChainConfig {
   bech32Prefix: string
   chainId: string
   gasPrice: string
-  restUri: string
+  restUri: string | string[]
   rpcUri: string | string[]
   wallets: WalletConfig[]
   feeFilter?: PacketFee

--- a/src/lib/restClient.spec.ts
+++ b/src/lib/restClient.spec.ts
@@ -1,0 +1,49 @@
+import nock from 'nock'
+import { RESTClient } from './restClient'
+import { logger } from './logger'
+
+const mockRestUris = [
+  'http://doi-rest-1.com',
+  'http://moro-rest-2.com',
+  'http://rene-rest-3.com',
+]
+
+describe('RESTClient', () => {
+  afterEach(() => {
+    nock.cleanAll()
+    jest.restoreAllMocks()
+  })
+
+  it('should use the first endpoint successfully', async () => {
+    nock(mockRestUris[0]).get('/cosmos/base/node/v1beta1/config').reply(200, {
+      minimum_gas_price: '0.01uinit',
+    })
+
+    const client = new RESTClient(mockRestUris)
+    const result = await client.apiRequester.get<{ minimum_gas_price: string }>(
+      '/cosmos/base/node/v1beta1/config'
+    )
+
+    expect(result.minimum_gas_price).toBe('0.01uinit')
+  })
+
+  it('should fallback to the next endpoint if the first one fails', async () => {
+    nock(mockRestUris[0]).get('/cosmos/base/node/v1beta1/config').reply(500)
+    nock(mockRestUris[1]).get('/cosmos/base/node/v1beta1/config').reply(200, {
+      minimum_gas_price: '0.02uinit',
+    })
+
+    const loggerSpy = jest.spyOn(logger, 'error')
+    const client = new RESTClient(mockRestUris)
+    const result = await client.apiRequester.get<{ minimum_gas_price: string }>(
+      '/cosmos/base/node/v1beta1/config'
+    )
+
+    expect(result.minimum_gas_price).toBe('0.02uinit')
+    expect(loggerSpy).toHaveBeenCalledWith(
+      expect.stringContaining(
+        `[REST] Failed to request to ${mockRestUris[0]} - /cosmos/base/node/v1beta1/config`
+      )
+    )
+  })
+})

--- a/src/lib/restClient.spec.ts
+++ b/src/lib/restClient.spec.ts
@@ -46,4 +46,39 @@ describe('RESTClient', () => {
       )
     )
   })
+
+  it('should not fallback on client errors', async () => {
+    nock(mockRestUris[0]).get('/cosmos/base/node/v1beta1/config').reply(404)
+    const fallback = nock(mockRestUris[1])
+      .get('/cosmos/base/node/v1beta1/config')
+      .reply(200, {
+        minimum_gas_price: '0.02uinit',
+      })
+
+    const client = new RESTClient(mockRestUris)
+
+    await expect(
+      client.apiRequester.get('/cosmos/base/node/v1beta1/config')
+    ).rejects.toThrow()
+    expect(fallback.isDone()).toBe(false)
+  })
+
+  it('should prefer the last successful endpoint for later requests', async () => {
+    nock(mockRestUris[0]).get('/cosmos/base/node/v1beta1/config').reply(500)
+    nock(mockRestUris[1]).get('/cosmos/base/node/v1beta1/config').reply(200, {
+      minimum_gas_price: '0.02uinit',
+    })
+    nock(mockRestUris[1]).get('/cosmos/base/node/v1beta1/config').reply(200, {
+      minimum_gas_price: '0.03uinit',
+    })
+
+    const client = new RESTClient(mockRestUris)
+
+    await client.apiRequester.get('/cosmos/base/node/v1beta1/config')
+    const result = await client.apiRequester.get<{ minimum_gas_price: string }>(
+      '/cosmos/base/node/v1beta1/config'
+    )
+
+    expect(result.minimum_gas_price).toBe('0.03uinit')
+  })
 })

--- a/src/lib/restClient.ts
+++ b/src/lib/restClient.ts
@@ -6,18 +6,164 @@ import {
   RESTClient as RESTClient_,
 } from '@initia/initia.js'
 import { Order, State } from '@initia/initia.proto/ibc/core/channel/v1/channel'
+import { logger } from './logger'
 import { ClientState, ConnectionInfo } from 'src/types'
+
+export type RESTUri = string | string[]
+
+type APIRequesterConfig = ConstructorParameters<typeof APIRequester>[1]
+type RESTParams = Parameters<APIRequester['get']>[1]
+type RESTHeaders = Parameters<APIRequester['get']>[2]
+type RESTData = Parameters<APIRequester['post']>[1]
+type RESTRequesterOptions = APIRequester | APIRequesterConfig
+interface RESTRequestState {
+  restUris: string[]
+  currentIndex: number
+  requesterConfig?: APIRequesterConfig
+}
+
+const MAX_RETRY = 10
+
+const normalizeRestUris = (URL: RESTUri): string[] => {
+  const restUris = Array.isArray(URL) ? URL : [URL]
+
+  if (restUris.length === 0) {
+    throw new Error('REST URI list cannot be empty')
+  }
+
+  return restUris
+}
 
 export class RESTClient extends RESTClient_ {
   public ibc: IbcAPI
+
   constructor(
-    URL: string,
+    URL: RESTUri,
     config?: RESTClientConfig,
-    apiRequester?: APIRequester
+    requesterOptions?: RESTRequesterOptions
   ) {
-    super(URL, config, apiRequester)
+    const requestState: RESTRequestState = {
+      restUris: normalizeRestUris(URL),
+      currentIndex: 0,
+      requesterConfig:
+        requesterOptions instanceof APIRequester ? undefined : requesterOptions,
+    }
+    const apiRequester =
+      requesterOptions instanceof APIRequester
+        ? requesterOptions
+        : RESTClient.createApiRequester(requestState)
+
+    super(requestState.restUris[0], config, apiRequester)
 
     this.ibc = new IbcAPI(this.apiRequester)
+  }
+
+  private static createApiRequester(state: RESTRequestState): APIRequester {
+    const client = RESTClient.getRequester(state.restUris[0], state)
+
+    client.getRaw = async <T>(
+      endpoint: string,
+      params?: RESTParams
+    ): Promise<T> => {
+      const { response } = await RESTClient.request<T>(
+        state,
+        'getRaw',
+        endpoint,
+        params
+      )
+      return response
+    }
+
+    client.get = async <T>(
+      endpoint: string,
+      params?: RESTParams,
+      headers?: RESTHeaders
+    ): Promise<T> => {
+      const { response } = await RESTClient.request<T>(
+        state,
+        'get',
+        endpoint,
+        params,
+        headers
+      )
+      return response
+    }
+
+    client.post = async <T>(endpoint: string, data?: RESTData): Promise<T> => {
+      const { response } = await RESTClient.request<T>(
+        state,
+        'post',
+        endpoint,
+        data
+      )
+      return response
+    }
+
+    return client
+  }
+
+  private static getRequester(
+    uri: string,
+    state: RESTRequestState
+  ): APIRequester {
+    return new APIRequester(uri, state.requesterConfig)
+  }
+
+  private static async request<T>(
+    state: RESTRequestState,
+    method: 'getRaw' | 'get' | 'post',
+    endpoint: string,
+    query?: RESTParams | RESTData,
+    headers?: RESTHeaders
+  ): Promise<{ response: T; uri: string }> {
+    let retryCount = 0
+
+    while (true) {
+      const uri = state.restUris[state.currentIndex]
+
+      try {
+        let response: T
+        const requester = RESTClient.getRequester(uri, state)
+
+        if (method === 'post') {
+          response = await requester.post<T>(endpoint, query)
+        } else if (method === 'getRaw') {
+          response = await requester.getRaw<T>(endpoint, query as RESTParams)
+        } else {
+          response = await requester.get<T>(
+            endpoint,
+            query as RESTParams,
+            headers
+          )
+        }
+
+        return { response, uri }
+      } catch (error) {
+        const errorContext = `[REST] Failed to request to ${uri} - ${endpoint}`
+
+        logger.error(`${errorContext}: ${String(error)}`)
+        state.currentIndex = (state.currentIndex + 1) % state.restUris.length
+
+        if (state.currentIndex === 0) {
+          let backoff = Math.pow(2, retryCount) * 1000
+          if (backoff > 10000) {
+            backoff = 10 * 1000
+          }
+
+          logger.info(`[REST] All endpoints failed. Retrying in ${backoff}ms`)
+          await new Promise((resolve) => setTimeout(resolve, backoff))
+          retryCount++
+          if (retryCount > MAX_RETRY) {
+            logger.error(`[REST] Max Retry Reached.`)
+            throw error
+          }
+        } else {
+          logger.info(
+            `[REST] Fallback to ${state.restUris[state.currentIndex]}`
+          )
+        }
+      }
+    }
   }
 }
 

--- a/src/lib/restClient.ts
+++ b/src/lib/restClient.ts
@@ -18,20 +18,31 @@ type RESTData = Parameters<APIRequester['post']>[1]
 type RESTRequesterOptions = APIRequester | APIRequesterConfig
 interface RESTRequestState {
   restUris: string[]
-  currentIndex: number
+  preferredIndex: number
   requesterConfig?: APIRequesterConfig
 }
 
 const MAX_RETRY = 10
 
 const normalizeRestUris = (URL: RESTUri): string[] => {
-  const restUris = Array.isArray(URL) ? URL : [URL]
+  const restUris = (Array.isArray(URL) ? URL : [URL]).map((uri) => uri.trim())
 
-  if (restUris.length === 0) {
-    throw new Error('REST URI list cannot be empty')
+  if (restUris.length === 0 || restUris.some((uri) => uri === '')) {
+    throw new Error(
+      'REST URI list must contain at least one non-empty endpoint'
+    )
   }
 
   return restUris
+}
+
+const getHttpStatus = (error: unknown): number | undefined => {
+  if (typeof error !== 'object' || error === null) {
+    return undefined
+  }
+
+  const response = (error as { response?: { status?: unknown } }).response
+  return typeof response?.status === 'number' ? response.status : undefined
 }
 
 export class RESTClient extends RESTClient_ {
@@ -44,7 +55,7 @@ export class RESTClient extends RESTClient_ {
   ) {
     const requestState: RESTRequestState = {
       restUris: normalizeRestUris(URL),
-      currentIndex: 0,
+      preferredIndex: 0,
       requesterConfig:
         requesterOptions instanceof APIRequester ? undefined : requesterOptions,
     }
@@ -117,9 +128,11 @@ export class RESTClient extends RESTClient_ {
     headers?: RESTHeaders
   ): Promise<{ response: T; uri: string }> {
     let retryCount = 0
+    const startIndex = state.preferredIndex
+    let currentIndex = startIndex
 
     while (true) {
-      const uri = state.restUris[state.currentIndex]
+      const uri = state.restUris[currentIndex]
 
       try {
         let response: T
@@ -137,14 +150,21 @@ export class RESTClient extends RESTClient_ {
           )
         }
 
+        state.preferredIndex = currentIndex
         return { response, uri }
       } catch (error) {
         const errorContext = `[REST] Failed to request to ${uri} - ${endpoint}`
 
         logger.error(`${errorContext}: ${String(error)}`)
-        state.currentIndex = (state.currentIndex + 1) % state.restUris.length
 
-        if (state.currentIndex === 0) {
+        const httpStatus = getHttpStatus(error)
+        if (httpStatus !== undefined && httpStatus >= 400 && httpStatus < 500) {
+          throw error
+        }
+
+        currentIndex = (currentIndex + 1) % state.restUris.length
+
+        if (currentIndex === startIndex) {
           let backoff = Math.pow(2, retryCount) * 1000
           if (backoff > 10000) {
             backoff = 10 * 1000
@@ -158,9 +178,7 @@ export class RESTClient extends RESTClient_ {
             throw error
           }
         } else {
-          logger.info(
-            `[REST] Fallback to ${state.restUris[state.currentIndex]}`
-          )
+          logger.info(`[REST] Fallback to ${state.restUris[currentIndex]}`)
         }
       }
     }

--- a/src/test/testSetup.ts
+++ b/src/test/testSetup.ts
@@ -10,6 +10,10 @@ import { setupServer } from 'msw/node'
 
 export let mockServers: { rest: RestMockServer }[] = []
 
+const firstUri = (uri: string | string[]): string => {
+  return Array.isArray(uri) ? uri[0] : uri
+}
+
 const setup = () => {
   // remove db
   const dbPath = config.dbPath as string
@@ -26,7 +30,8 @@ const setup = () => {
   mockServers = config.chains.map((chain, i) => {
     const index = i + 1
     const counterpartyIndex = index + (index % 2 === 0 ? -1 : 1)
-    const restServer = new RestMockServer(chain.chainId, chain.restUri)
+    const restUri = firstUri(chain.restUri)
+    const restServer = new RestMockServer(chain.chainId, restUri)
 
     restServer.addClientState(`07-tendermint-${index}`, {
       client_state: {
@@ -49,10 +54,8 @@ const setup = () => {
 
     handlers.push(
       http.get(
-        new URL(
-          '/ibc/core/connection/v1/connections/:connectionId',
-          chain.restUri
-        ).href,
+        new URL('/ibc/core/connection/v1/connections/:connectionId', restUri)
+          .href,
         ({ params }) => {
           const { connectionId } = params
           // ...and respond to them using this JSON response.
@@ -72,8 +75,7 @@ const setup = () => {
 
     handlers.push(
       http.get(
-        new URL('/ibc/core/client/v1/client_states/:clientId', chain.restUri)
-          .href,
+        new URL('/ibc/core/client/v1/client_states/:clientId', restUri).href,
         ({ params }) => {
           const { clientId } = params
 
@@ -93,7 +95,7 @@ const setup = () => {
       http.get(
         new URL(
           '/ibc/core/client/v1/consensus_states/:clientId/revision/0/height/0',
-          chain.restUri
+          restUri
         ).href,
         () => {
           return HttpResponse.json({

--- a/src/test/testSetup.ts
+++ b/src/test/testSetup.ts
@@ -11,7 +11,13 @@ import { setupServer } from 'msw/node'
 export let mockServers: { rest: RestMockServer }[] = []
 
 const firstUri = (uri: string | string[]): string => {
-  return Array.isArray(uri) ? uri[0] : uri
+  if (Array.isArray(uri)) {
+    if (uri.length === 0) {
+      throw new Error('restUri must contain at least one entry')
+    }
+    return uri[0]
+  }
+  return uri
 }
 
 const setup = () => {

--- a/src/workers/index.ts
+++ b/src/workers/index.ts
@@ -19,7 +19,6 @@ import {
   PacketWriteAckTable,
 } from 'src/types'
 import {
-  APIRequester,
   Coins,
   Key,
   MnemonicKey,
@@ -95,11 +94,11 @@ export class WorkerController {
           chainId: chainConfig.chainId,
           gasPrices: chainConfig.gasPrice,
         },
-        new APIRequester(chainConfig.restUri, {
+        {
           httpAgent: new http.Agent({ keepAlive: true }),
           httpsAgent: new https.Agent({ keepAlive: true }),
           timeout: 60000,
-        })
+        }
       )
       const rpc = new RPCClient(chainConfig.rpcUri)
       const latestHeight = await queryLatestHeight(rpc)


### PR DESCRIPTION
## Summary

- Support REST URI config as either a single string or a JSON array of fallback endpoints.
- Route initia.js REST requests through fallback REST endpoints while keeping the worker API as `new RESTClient(chainConfig.restUri, ...)`.
- Update config schema, examples, docs, and tests for REST URI arrays.

## Why

Some public REST/RPC providers periodically state-sync or reset nodes when they have node issues. When that happens, historical state around the last height used for `MsgUpdateClient` proof generation can be pruned or unavailable from that endpoint. Even if another provider still has the required state, the relayer previously had no REST fallback path, so update-client generation could fail or keep retrying against an endpoint that can no longer serve the needed height.

Allowing multiple REST URIs lets the relayer fail over to another endpoint that may still retain the required historical state, reducing client update failures caused by provider pruning, state-sync resets, or transient REST node issues.

## Validation

- `./node_modules/.bin/tsc --noEmit --incremental false`
- `./node_modules/.bin/jest src/lib/config.spec.ts src/lib/restClient.spec.ts --runInBand --config '{"preset":"ts-jest","testEnvironment":"node","moduleNameMapper":{"^src/(.*)$":"<rootDir>/src/$1"}}'`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for multiple REST and RPC endpoints with automatic fallback to alternate endpoints if the primary fails.
  * Configuration now accepts both single URI strings and arrays of URIs for flexible endpoint management.

* **Documentation**
  * Updated configuration examples and documentation to reflect multiple URI support.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->