### PR TITLE
fix: reconcile account info on broadcast failure

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -104,7 +104,6 @@
       "integrity": "sha512-i1SLeK+DzNnQ3LL/CswPCa/E5u4lh1k6IAEphON8F+cXt0t9euTshDru0q7/IqMa1PMPz5RnHuHscF8/ZJsStg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@ampproject/remapping": "^2.2.0",
         "@babel/code-frame": "^7.26.0",
@@ -646,6 +645,12 @@
         "@noble/curves": "^1.7.0"
       }
     },
+    "node_modules/@bufbuild/protobuf": {
+      "version": "2.12.0",
+      "resolved": "https://registry.npmjs.org/@bufbuild/protobuf/-/protobuf-2.12.0.tgz",
+      "integrity": "sha512-B/XlCaFIP8LOwzo+bz5uFzATYokcwCKQcghqnlfwSmM5eX/qTkvDBnDPs+gXtX/RyjxJ4DRikECcPJbyALA8FA==",
+      "license": "(Apache-2.0 AND BSD-3-Clause)"
+    },
     "node_modules/@bundled-es-modules/cookie": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/@bundled-es-modules/cookie/-/cookie-2.0.1.tgz",
@@ -707,7 +712,9 @@
       "license": "Apache-2.0"
     },
     "node_modules/@confio/ics23/node_modules/protobufjs": {
-      "version": "6.11.4",
+      "version": "6.11.6",
+      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-6.11.6.tgz",
+      "integrity": "sha512-k8BHqgPBOtrlougZZqF2uUk5Z7bN8f0wj+3e8M3hvtSv0NBAz4VBy5f6R5Nxq/l+i7mRFTgNZb2trxqTpHNY/A==",
       "hasInstallScript": true,
       "license": "BSD-3-Clause",
       "dependencies": {
@@ -1132,23 +1139,21 @@
       }
     },
     "node_modules/@initia/initia.js": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@initia/initia.js/-/initia.js-1.0.0.tgz",
-      "integrity": "sha512-A1JYv8Vxec3COEy65HFHf8QDJYVVxIBU3MyiysfK9RJLdWcRwNTRP7V407bHUeQaQHB4oE1M9BqumPxFuOmioQ==",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@initia/initia.js/-/initia.js-1.1.0.tgz",
+      "integrity": "sha512-AQe7EmjupQH+UNgwbO3xGrcO5Vj+KZTOKvG0iX9wW9lQ1AOKt0DdBXhrFeTIsWhTPdN2t3D9hIsjdfKub8e1/Q==",
       "license": "Apache-2.0",
       "dependencies": {
         "@bitcoinerlab/secp256k1": "^1.1.1",
-        "@initia/initia.proto": "^0.2.6",
-        "@initia/opinit.proto": "^0.0.11",
-        "@ledgerhq/hw-transport": "^6.31.4",
-        "@ledgerhq/hw-transport-webhid": "^6.29.4",
-        "@ledgerhq/hw-transport-webusb": "^6.29.4",
+        "@initia/initia.proto": "^1.0.5",
+        "@initia/opinit.proto": "^1.0.3",
         "@mysten/bcs": "^1.1.0",
-        "axios": "^1.7.7",
+        "axios": "1.14.0",
         "bech32": "^2.0.0",
         "bignumber.js": "^9.1.2",
         "bip32": "^5.0.0-rc.0",
         "bip39": "^3.1.0",
+        "events": "^3.3.0",
         "jscrypto": "^1.0.3",
         "keccak256": "^1.0.6",
         "ripemd160": "^2.0.2",
@@ -1160,10 +1165,21 @@
         "node": ">=20"
       }
     },
+    "node_modules/@initia/initia.js/node_modules/@initia/initia.proto": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/@initia/initia.proto/-/initia.proto-1.0.6.tgz",
+      "integrity": "sha512-TvJKSOJGb+MCCAUOz796F5yIJHf/9gt7I1Y3+PJt0IY8IQGvskghhFagHBVqqQmI40IenyX7SYdzy+MH4QG89g==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@bufbuild/protobuf": "^2.5.2",
+        "@improbable-eng/grpc-web": "^0.15.0",
+        "browser-headers": "^0.4.1"
+      }
+    },
     "node_modules/@initia/initia.js/node_modules/ws": {
-      "version": "8.18.0",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.18.0.tgz",
-      "integrity": "sha512-8VbfWfHLbbwu3+N6OKsOMpBdT4kXPDDB9cJk2bJ6mh9ucxdlnNvH1e+roYkKmN9Nxw2yjz7VzeO9oOz2zJ04Pw==",
+      "version": "8.21.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.0.tgz",
+      "integrity": "sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g==",
       "license": "MIT",
       "engines": {
         "node": ">=10.0.0"
@@ -1194,15 +1210,14 @@
       }
     },
     "node_modules/@initia/opinit.proto": {
-      "version": "0.0.11",
-      "resolved": "https://registry.npmjs.org/@initia/opinit.proto/-/opinit.proto-0.0.11.tgz",
-      "integrity": "sha512-Op9GIlXiV1xhUIjVQ2TFE9a3X8iyFVNtJNHCM34gwLQHJktDNm2KCoW4eHh6pkn4//ECRVH7zuKgV8TdZWogCw==",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@initia/opinit.proto/-/opinit.proto-1.0.3.tgz",
+      "integrity": "sha512-GxFlNsk4V2+drjsXFWTccQSv0+Ho77V9fmsKpLpzXONVHpkP50XcXdWKVRayys/D7gxTcOwvaXSWuj5maA814g==",
       "license": "Apache-2.0",
       "dependencies": {
+        "@bufbuild/protobuf": "^2.5.2",
         "@improbable-eng/grpc-web": "^0.15.0",
-        "google-protobuf": "^3.21.4",
-        "long": "^5.2.3",
-        "protobufjs": "^7.3.2"
+        "browser-headers": "^0.4.1"
       }
     },
     "node_modules/@inquirer/confirm": {
@@ -1336,9 +1351,9 @@
       }
     },
     "node_modules/@istanbuljs/load-nyc-config/node_modules/js-yaml": {
-      "version": "3.14.1",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.1.tgz",
-      "integrity": "sha512-okMH7OXXJ7YrN9Ok3/SXrnu4iX9yOk+25nqX4imS2npuvTYDmo/QEZoqwZkYaIDk3jVvBOTOIEgEhaLOynBS9g==",
+      "version": "3.14.2",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.2.tgz",
+      "integrity": "sha512-PMSmkqxr106Xa156c2M265Z+FTrPl+oxd/rgOQy2tijQeK5TxQ43psO1ZCwhVOSdnn+RzkzlRz/eY4BgJBYVpg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1791,66 +1806,6 @@
         "@jridgewell/sourcemap-codec": "^1.4.10"
       }
     },
-    "node_modules/@ledgerhq/devices": {
-      "version": "8.4.4",
-      "resolved": "https://registry.npmjs.org/@ledgerhq/devices/-/devices-8.4.4.tgz",
-      "integrity": "sha512-sz/ryhe/R687RHtevIE9RlKaV8kkKykUV4k29e7GAVwzHX1gqG+O75cu1NCJUHLbp3eABV5FdvZejqRUlLis9A==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@ledgerhq/errors": "^6.19.1",
-        "@ledgerhq/logs": "^6.12.0",
-        "rxjs": "^7.8.1",
-        "semver": "^7.3.5"
-      }
-    },
-    "node_modules/@ledgerhq/errors": {
-      "version": "6.19.1",
-      "resolved": "https://registry.npmjs.org/@ledgerhq/errors/-/errors-6.19.1.tgz",
-      "integrity": "sha512-75yK7Nnit/Gp7gdrJAz0ipp31CCgncRp+evWt6QawQEtQKYEDfGo10QywgrrBBixeRxwnMy1DP6g2oCWRf1bjw==",
-      "license": "Apache-2.0"
-    },
-    "node_modules/@ledgerhq/hw-transport": {
-      "version": "6.31.4",
-      "resolved": "https://registry.npmjs.org/@ledgerhq/hw-transport/-/hw-transport-6.31.4.tgz",
-      "integrity": "sha512-6c1ir/cXWJm5dCWdq55NPgCJ3UuKuuxRvf//Xs36Bq9BwkV2YaRQhZITAkads83l07NAdR16hkTWqqpwFMaI6A==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@ledgerhq/devices": "^8.4.4",
-        "@ledgerhq/errors": "^6.19.1",
-        "@ledgerhq/logs": "^6.12.0",
-        "events": "^3.3.0"
-      }
-    },
-    "node_modules/@ledgerhq/hw-transport-webhid": {
-      "version": "6.30.0",
-      "resolved": "https://registry.npmjs.org/@ledgerhq/hw-transport-webhid/-/hw-transport-webhid-6.30.0.tgz",
-      "integrity": "sha512-HoTzjmYwO7+TVwK+GNbglRepUoDywBL6vjhKnhGqJSUPqAqJJyEXcnKnFDBMN7Phqm55O+YHDYfpcHGBNg5XlQ==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@ledgerhq/devices": "8.4.4",
-        "@ledgerhq/errors": "^6.19.1",
-        "@ledgerhq/hw-transport": "^6.31.4",
-        "@ledgerhq/logs": "^6.12.0"
-      }
-    },
-    "node_modules/@ledgerhq/hw-transport-webusb": {
-      "version": "6.29.4",
-      "resolved": "https://registry.npmjs.org/@ledgerhq/hw-transport-webusb/-/hw-transport-webusb-6.29.4.tgz",
-      "integrity": "sha512-HoGF1LlBT9HEGBQy2XeCHrFdv/FEOZU0+J+yfKcgAQIAiASr2MLvdzwoJbUS8h6Gn+vc+/BjzBSO3JNn7Loqbg==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@ledgerhq/devices": "^8.4.4",
-        "@ledgerhq/errors": "^6.19.1",
-        "@ledgerhq/hw-transport": "^6.31.4",
-        "@ledgerhq/logs": "^6.12.0"
-      }
-    },
-    "node_modules/@ledgerhq/logs": {
-      "version": "6.12.0",
-      "resolved": "https://registry.npmjs.org/@ledgerhq/logs/-/logs-6.12.0.tgz",
-      "integrity": "sha512-ExDoj1QV5eC6TEbMdLUMMk9cfvNKhhv5gXol4SmULRVCx/3iyCPhJ74nsb3S0Vb+/f+XujBEj3vQn5+cwS0fNA==",
-      "license": "Apache-2.0"
-    },
     "node_modules/@mswjs/interceptors": {
       "version": "0.36.10",
       "resolved": "https://registry.npmjs.org/@mswjs/interceptors/-/interceptors-0.36.10.tgz",
@@ -1972,7 +1927,6 @@
       "version": "1.9.0",
       "resolved": "https://registry.npmjs.org/@opentelemetry/api/-/api-1.9.0.tgz",
       "integrity": "sha512-3giAOQvZiH5F9bMlMiv8+GSPMeqg0dbaeo58/0SlA9sxSqZhnUtxzX9/2FzyhS9sWQf5S0GJE0AKBrFqjpeYcg==",
-      "peer": true,
       "engines": {
         "node": ">=8.0.0"
       }
@@ -2006,7 +1960,6 @@
       "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-1.30.1.tgz",
       "integrity": "sha512-OOCM2C/QIURhJMuKaekP3TRBxBKxG/TWWA0TL2J6nXUtDnuCtccy49LUJF8xPFXMX+0LMcxFpCo8M9cGY1W6rQ==",
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "@opentelemetry/semantic-conventions": "1.28.0"
       },
@@ -2022,7 +1975,6 @@
       "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation/-/instrumentation-0.56.0.tgz",
       "integrity": "sha512-2KkGBKE+FPXU1F0zKww+stnlUxUTlBvLCiWdP63Z9sqXYeNI/ziNzsxAp4LAdUcTQmXjw1IWgvm5CAb/BHy99w==",
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "@opentelemetry/api-logs": "0.56.0",
         "@types/shimmer": "^1.2.0",
@@ -2501,7 +2453,6 @@
       "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-trace-base/-/sdk-trace-base-1.30.1.tgz",
       "integrity": "sha512-jVPgBbH1gCy2Lb7X0AVQ8XAfgg0pJ4nvl8/IiQA6nxOsPvS+0zMJaFSs2ltXe0J6C8dqjcnpyqINDJmU30+uOg==",
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "@opentelemetry/core": "1.30.1",
         "@opentelemetry/resources": "1.30.1",
@@ -2519,7 +2470,6 @@
       "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.28.0.tgz",
       "integrity": "sha512-lp4qAiMTD4sNWW4DbKLBkfiMZ4jbAboJIGOQr5DvciMRI494OapieI9qiODpOt0XBr1LjIDy1xAGAnVs5supTA==",
       "license": "Apache-2.0",
-      "peer": true,
       "engines": {
         "node": ">=14"
       }
@@ -2604,19 +2554,24 @@
       "license": "BSD-3-Clause"
     },
     "node_modules/@protobufjs/codegen": {
-      "version": "2.0.4",
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/@protobufjs/codegen/-/codegen-2.0.5.tgz",
+      "integrity": "sha512-zgXFLzW3Ap33e6d0Wlj4MGIm6Ce8O89n/apUaGNB/jx+hw+ruWEp7EwGUshdLKVRCxZW12fp9r40E1mQrf/34g==",
       "license": "BSD-3-Clause"
     },
     "node_modules/@protobufjs/eventemitter": {
-      "version": "1.1.0",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@protobufjs/eventemitter/-/eventemitter-1.1.1.tgz",
+      "integrity": "sha512-vW1GmwMZNnL+gMRaovlh9yZX74kc+TTU3FObkkurpMaRtBfLP3ldjS9KQWlwZgraRE0+dheEEoAxdzcJQ8eXZg==",
       "license": "BSD-3-Clause"
     },
     "node_modules/@protobufjs/fetch": {
-      "version": "1.1.0",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@protobufjs/fetch/-/fetch-1.1.1.tgz",
+      "integrity": "sha512-GpptLrs57adMSuHi3VNj0mAF8dwh36LMaYF6XyJ6JMWlVsc+t42tm1HSEDmOs3A8fC9yyeisgLhsTVQokOZ0zw==",
       "license": "BSD-3-Clause",
       "dependencies": {
-        "@protobufjs/aspromise": "^1.1.1",
-        "@protobufjs/inquire": "^1.1.0"
+        "@protobufjs/aspromise": "^1.1.1"
       }
     },
     "node_modules/@protobufjs/float": {
@@ -2624,7 +2579,9 @@
       "license": "BSD-3-Clause"
     },
     "node_modules/@protobufjs/inquire": {
-      "version": "1.1.0",
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/inquire/-/inquire-1.1.2.tgz",
+      "integrity": "sha512-pa0vFRuws4wkvaXKK1uXZMAwAX4/t8ANaJo45iw/oQHNQ9q5xUzwgFmVJGXiga2BeN+zpX7Vf9vmsiIa2J+MUw==",
       "license": "BSD-3-Clause"
     },
     "node_modules/@protobufjs/path": {
@@ -2636,7 +2593,9 @@
       "license": "BSD-3-Clause"
     },
     "node_modules/@protobufjs/utf8": {
-      "version": "1.1.0",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@protobufjs/utf8/-/utf8-1.1.1.tgz",
+      "integrity": "sha512-oOAWABowe8EAbMyWKM0tYDKi8Yaox52D+HWZhAIJqQXbqe0xI/GV7FhLWqlEKreMkfDjshR5FKgi3mnle0h6Eg==",
       "license": "BSD-3-Clause"
     },
     "node_modules/@scure/base": {
@@ -3049,7 +3008,6 @@
       "version": "22.5.4",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-22.5.4.tgz",
       "integrity": "sha512-FDuKUJQm/ju9fT/SeX/6+gBzoPzlVCzfzmGkwKvRHQVxi4BntVbyIwf6a4Xn62mrvndLiml6z/UBXIdEVjQLXg==",
-      "peer": true,
       "dependencies": {
         "undici-types": "~6.19.2"
       }
@@ -3224,9 +3182,9 @@
       }
     },
     "node_modules/@typescript-eslint/typescript-estree/node_modules/brace-expansion": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.2.tgz",
-      "integrity": "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==",
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.1.tgz",
+      "integrity": "sha512-WR1cURNjuvBLMZBMbqM0UoE+WAfdUcEV1ccD8PVBVOI+Z3ND4+SZbN8RsfT2bMuG1qwz5RFvPukSZm5fF2D5eA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -3251,12 +3209,13 @@
       }
     },
     "node_modules/@typescript-eslint/typescript-estree/node_modules/minimatch": {
-      "version": "9.0.5",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.5.tgz",
-      "integrity": "sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow==",
+      "version": "9.0.9",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.9.tgz",
+      "integrity": "sha512-OBwBN9AL4dqmETlpS2zasx+vTeWclWzkblfZk7KTA5j3jeOONz/tRCnZomUyvNg83wL5Zv9Ss6HMJXAgL8R2Yg==",
       "dev": true,
+      "license": "ISC",
       "dependencies": {
-        "brace-expansion": "^2.0.1"
+        "brace-expansion": "^2.0.2"
       },
       "engines": {
         "node": ">=16 || 14 >=14.17"
@@ -3343,7 +3302,6 @@
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.15.0.tgz",
       "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -3378,9 +3336,9 @@
       }
     },
     "node_modules/ajv": {
-      "version": "6.12.6",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
-      "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
+      "version": "6.15.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.15.0.tgz",
+      "integrity": "sha512-fgFx7Hfoq60ytK2c7DhnF8jIvzYgOMxfugjLOSMHjLIPgenqa7S7oaagATUq99mV6IYvN2tRmC0wnTYX6iPbMw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -3506,14 +3464,14 @@
       "license": "MIT"
     },
     "node_modules/axios": {
-      "version": "1.13.1",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.13.1.tgz",
-      "integrity": "sha512-hU4EGxxt+j7TQijx1oYdAjw4xuIp1wRQSsbMFwSthCWeBQur1eF+qJ5iQ5sN3Tw8YRzQNKb8jszgBdMDVqwJcw==",
+      "version": "1.14.0",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.14.0.tgz",
+      "integrity": "sha512-3Y8yrqLSwjuzpXuZ0oIYZ/XGgLwUIBU3uLvbcpb0pidD9ctpShJd43KSlEEkVQg6DS0G9NKyzOvBfUtDKEyHvQ==",
       "license": "MIT",
       "dependencies": {
-        "follow-redirects": "^1.15.6",
-        "form-data": "^4.0.4",
-        "proxy-from-env": "^1.1.0"
+        "follow-redirects": "^1.15.11",
+        "form-data": "^4.0.5",
+        "proxy-from-env": "^2.1.0"
       }
     },
     "node_modules/babel-jest": {
@@ -3708,15 +3666,15 @@
       "integrity": "sha512-VOMgTMwjAaUG580SXn3LacVgjurrbMme7ZZNYGSSV7mmtY6QQRh0Eg3pwIcntQ77DErK1L0NxkbetjcoXzVwKw=="
     },
     "node_modules/bip32": {
-      "version": "5.0.0-rc.0",
-      "resolved": "https://registry.npmjs.org/bip32/-/bip32-5.0.0-rc.0.tgz",
-      "integrity": "sha512-5hVFGrdCnF8GB1Lj2eEo4PRE7+jp+3xBLnfNjydivOkMvKmUKeJ9GG8uOy8prmWl3Oh154uzgfudR1FRkNBudA==",
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/bip32/-/bip32-5.0.1.tgz",
+      "integrity": "sha512-PWlHIAgYCfVhwqNpZyeakHXuLAGyN6rEQZnhxHxKI3BoFJRVWLl26455fhRlHsmbYcV986HqtPnt33Edu5sTCw==",
       "license": "MIT",
       "dependencies": {
         "@noble/hashes": "^1.2.0",
         "@scure/base": "^1.1.1",
         "uint8array-tools": "^0.0.8",
-        "valibot": "^0.37.0",
+        "valibot": "^1.2.0",
         "wif": "^5.0.0"
       },
       "engines": {
@@ -3765,37 +3723,68 @@
       }
     },
     "node_modules/bn.js": {
-      "version": "5.2.1",
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-5.2.3.tgz",
+      "integrity": "sha512-EAcmnPkxpntVL+DS7bO1zhcZNvCkxqtkd0ZY53h06GNQ3DEkkGZ/gKgmDv6DdZQGj9BgfSPKtJJ7Dp1GPP8f7w==",
       "license": "MIT"
     },
     "node_modules/body-parser": {
-      "version": "1.20.3",
-      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.20.3.tgz",
-      "integrity": "sha512-7rAxByjUMqQ3/bHJy7D6OGXvx/MMc4IqBn/X0fcM1QUcAItpZrBEYhWGem+tzXH90c+G01ypMcYJBO9Y30203g==",
+      "version": "1.20.5",
+      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.20.5.tgz",
+      "integrity": "sha512-3grm+/2tUOvu2cjJkvsIxrv/wVpfXQW4PsQHYm7yk4vfpu7Ekl6nEsYBoJUL6qDwZUx8wUhQ8tR2qz+ad9c9OA==",
       "license": "MIT",
       "dependencies": {
-        "bytes": "3.1.2",
+        "bytes": "~3.1.2",
         "content-type": "~1.0.5",
         "debug": "2.6.9",
         "depd": "2.0.0",
-        "destroy": "1.2.0",
-        "http-errors": "2.0.0",
-        "iconv-lite": "0.4.24",
-        "on-finished": "2.4.1",
-        "qs": "6.13.0",
-        "raw-body": "2.5.2",
+        "destroy": "~1.2.0",
+        "http-errors": "~2.0.1",
+        "iconv-lite": "~0.4.24",
+        "on-finished": "~2.4.1",
+        "qs": "~6.15.1",
+        "raw-body": "~2.5.3",
         "type-is": "~1.6.18",
-        "unpipe": "1.0.0"
+        "unpipe": "~1.0.0"
       },
       "engines": {
         "node": ">= 0.8",
         "npm": "1.2.8000 || >= 1.4.16"
       }
     },
+    "node_modules/body-parser/node_modules/http-errors": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.1.tgz",
+      "integrity": "sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ==",
+      "license": "MIT",
+      "dependencies": {
+        "depd": "~2.0.0",
+        "inherits": "~2.0.4",
+        "setprototypeof": "~1.2.0",
+        "statuses": "~2.0.2",
+        "toidentifier": "~1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/body-parser/node_modules/statuses": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.2.tgz",
+      "integrity": "sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
     "node_modules/brace-expansion": {
-      "version": "1.1.12",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
-      "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
+      "version": "1.1.15",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.15.tgz",
+      "integrity": "sha512-EwOCDEex4quD37XhqM3omwtMoJjr//isUZz1JopUNWms+4Z2ViyM/k1YIRePpoVNnQhENnxtFjLaxNHrT7xIUg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -3845,7 +3834,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "caniuse-lite": "^1.0.30001669",
         "electron-to-chromium": "^1.5.41",
@@ -3940,25 +3928,6 @@
         "node": ">= 0.8"
       }
     },
-    "node_modules/call-bind": {
-      "version": "1.0.7",
-      "resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.7.tgz",
-      "integrity": "sha512-GHTSNSYICQ7scH7sZ+M2rFopRoLh8t2bLSW6BbgrtLsahOIB5iyAVJf9GjWK3cYTDaMj4XdBpM1cA6pIS0Kv2w==",
-      "license": "MIT",
-      "dependencies": {
-        "es-define-property": "^1.0.0",
-        "es-errors": "^1.3.0",
-        "function-bind": "^1.1.2",
-        "get-intrinsic": "^1.2.4",
-        "set-function-length": "^1.2.1"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
     "node_modules/call-bind-apply-helpers": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
@@ -3970,6 +3939,22 @@
       },
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/call-bound": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/call-bound/-/call-bound-1.0.4.tgz",
+      "integrity": "sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "get-intrinsic": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/callsites": {
@@ -4392,7 +4377,9 @@
       }
     },
     "node_modules/diff": {
-      "version": "4.0.2",
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/diff/-/diff-4.0.4.tgz",
+      "integrity": "sha512-X07nttJQkwkfKfvTPG/KSnE2OMdcUCao6+eXF3wmnIQRn2aPAHH3VxDbDOdegkd6JbPsXqShpvEOHfAT+nCNwQ==",
       "license": "BSD-3-Clause",
       "engines": {
         "node": ">=0.3.1"
@@ -4467,7 +4454,9 @@
       }
     },
     "node_modules/elliptic/node_modules/bn.js": {
-      "version": "4.12.0",
+      "version": "4.12.3",
+      "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.12.3.tgz",
+      "integrity": "sha512-fGTi3gxV/23FTYdAoUtLYp6qySe2KE3teyZitipKNRuVYcBkoP/bB3guXN/XVKUe9mxCHXnc9C4ocyz8OmgN0g==",
       "license": "MIT"
     },
     "node_modules/emittery": {
@@ -4545,9 +4534,9 @@
       }
     },
     "node_modules/es-object-atoms": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
-      "integrity": "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==",
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.2.tgz",
+      "integrity": "sha512-HWcBoN6NileqtSydK2FqHbS/LoDd2pqrnQHLyJzBj4kOp/ky2MWMN694xOfkK8/SnUsW2DH7EfyVlydKCsm1Zw==",
       "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0"
@@ -4605,7 +4594,6 @@
       "integrity": "sha512-iy2GE3MHrYTL5lrCtMZ0X1KLEKKUjmK0kzwcnefhR66txcEmXZD2YWgR5GNdcEwkNx3a0siYkSvl0vIC+Svjmg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -4666,7 +4654,6 @@
       "integrity": "sha512-NSWl5BFQWEPi1j4TjVNItzYV7dZXZ+wP6I6ZhrBGpChQhZRUaElihE9uRRkcbRnNb76UMKDF3r+WTmNcGPKsqw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "eslint-config-prettier": "bin/cli.js"
       },
@@ -4936,39 +4923,39 @@
       }
     },
     "node_modules/express": {
-      "version": "4.21.2",
-      "resolved": "https://registry.npmjs.org/express/-/express-4.21.2.tgz",
-      "integrity": "sha512-28HqgMZAmih1Czt9ny7qr6ek2qddF4FclbMzwhCREB6OFfH+rXAnuNCwo1/wFvrtbgsQDb4kSbX9de9lFbrXnA==",
+      "version": "4.22.2",
+      "resolved": "https://registry.npmjs.org/express/-/express-4.22.2.tgz",
+      "integrity": "sha512-IuL+Elrou2ZvCFHs18/CIzy2Nzvo25nZ1/D2eIZlz7c+QUayAcYoiM2BthCjs+EBHVpjYjcuLDAiCWgeIX3X1Q==",
       "license": "MIT",
       "dependencies": {
         "accepts": "~1.3.8",
         "array-flatten": "1.1.1",
-        "body-parser": "1.20.3",
-        "content-disposition": "0.5.4",
+        "body-parser": "~1.20.5",
+        "content-disposition": "~0.5.4",
         "content-type": "~1.0.4",
-        "cookie": "0.7.1",
-        "cookie-signature": "1.0.6",
+        "cookie": "~0.7.1",
+        "cookie-signature": "~1.0.6",
         "debug": "2.6.9",
         "depd": "2.0.0",
         "encodeurl": "~2.0.0",
         "escape-html": "~1.0.3",
         "etag": "~1.8.1",
-        "finalhandler": "1.3.1",
-        "fresh": "0.5.2",
-        "http-errors": "2.0.0",
+        "finalhandler": "~1.3.1",
+        "fresh": "~0.5.2",
+        "http-errors": "~2.0.0",
         "merge-descriptors": "1.0.3",
         "methods": "~1.1.2",
-        "on-finished": "2.4.1",
+        "on-finished": "~2.4.1",
         "parseurl": "~1.3.3",
-        "path-to-regexp": "0.1.12",
+        "path-to-regexp": "~0.1.12",
         "proxy-addr": "~2.0.7",
-        "qs": "6.13.0",
+        "qs": "~6.15.1",
         "range-parser": "~1.2.1",
         "safe-buffer": "5.2.1",
-        "send": "0.19.0",
-        "serve-static": "1.16.2",
+        "send": "~0.19.0",
+        "serve-static": "~1.16.2",
         "setprototypeof": "1.2.0",
-        "statuses": "2.0.1",
+        "statuses": "~2.0.1",
         "type-is": "~1.6.18",
         "utils-merge": "1.0.1",
         "vary": "~1.1.2"
@@ -5089,9 +5076,9 @@
       }
     },
     "node_modules/filelist/node_modules/brace-expansion": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.2.tgz",
-      "integrity": "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==",
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.1.tgz",
+      "integrity": "sha512-WR1cURNjuvBLMZBMbqM0UoE+WAfdUcEV1ccD8PVBVOI+Z3ND4+SZbN8RsfT2bMuG1qwz5RFvPukSZm5fF2D5eA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -5099,9 +5086,9 @@
       }
     },
     "node_modules/filelist/node_modules/minimatch": {
-      "version": "5.1.6",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.1.6.tgz",
-      "integrity": "sha512-lKwV/1brpG6mBUFHtb7NUmtABCb2WZZmm2wNiOA5hAb8VdCS4B3dtMWyvcoViccwAW/COERjXLt0zP1zXUN26g==",
+      "version": "5.1.9",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.1.9.tgz",
+      "integrity": "sha512-7o1wEA2RyMP7Iu7GNba9vc0RWWGACJOCZBJX2GJWip0ikV+wcOsgVuY9uE8CPiyQhkGFSlhuSkZPavN7u1c2Fw==",
       "dev": true,
       "license": "ISC",
       "dependencies": {
@@ -5172,9 +5159,9 @@
       }
     },
     "node_modules/flatted": {
-      "version": "3.3.2",
-      "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.3.2.tgz",
-      "integrity": "sha512-AiwGJM8YcNOaobumgtng+6NHuOqC3A7MixFeDafM3X9cIUM+xUXoS5Vfgf+OihAYe20fxqNM9yPBXJzRtZ/4eA==",
+      "version": "3.4.2",
+      "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.4.2.tgz",
+      "integrity": "sha512-PjDse7RzhcPkIJwy5t7KPWQSZ9cAbzQXcafsetQoD7sOJRQlGikNbx7yZp2OotDnJyrDcbyRq3Ttb18iYOqkxA==",
       "dev": true,
       "license": "ISC"
     },
@@ -5183,7 +5170,9 @@
       "license": "MIT"
     },
     "node_modules/follow-redirects": {
-      "version": "1.15.6",
+      "version": "1.16.0",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.16.0.tgz",
+      "integrity": "sha512-y5rN/uOsadFT/JfYwhxRS5R7Qce+g3zG97+JrtFZlC9klX/W5hD7iiLzScI4nZqUS7DNUdhPgw4xI8W2LuXlUw==",
       "funding": [
         {
           "type": "individual",
@@ -5201,9 +5190,9 @@
       }
     },
     "node_modules/form-data": {
-      "version": "4.0.4",
-      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.4.tgz",
-      "integrity": "sha512-KrGhL9Q4zjj0kiUt5OO4Mr/A/jlI2jDYs5eHBpYHPcBEVSiipAvn2Ko2HnPe20rmcuuvMHNdZFp+4IlGTMF0Ow==",
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.5.tgz",
+      "integrity": "sha512-8RipRLol37bNs2bhoV67fiTEvdTrbMUYcFTiy3+wuuOnUog2QBHCZWXDRijWQfAkhBj2Uf5UnVaiWwA5vdd82w==",
       "license": "MIT",
       "dependencies": {
         "asynckit": "^0.4.0",
@@ -5421,8 +5410,7 @@
       "version": "3.21.4",
       "resolved": "https://registry.npmjs.org/google-protobuf/-/google-protobuf-3.21.4.tgz",
       "integrity": "sha512-MnG7N936zcKTco4Jd2PX2U96Kf9PxygAPKBug+74LHzmHXmceN16MmRcdgZv+DGef/S9YvQAfRsNCn4cjf9yyQ==",
-      "license": "(BSD-3-Clause AND Apache-2.0)",
-      "peer": true
+      "license": "(BSD-3-Clause AND Apache-2.0)"
     },
     "node_modules/gopd": {
       "version": "1.2.0",
@@ -5942,7 +5930,6 @@
       "integrity": "sha512-NIy3oAFp9shda19hy4HK0HRTWKtPJmGdnvywu01nOqNC2vZg+Z+fvJDxpMQA88eb2I9EcafcdjYgsDthnYTvGw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@jest/core": "^29.7.0",
         "@jest/types": "^29.6.3",
@@ -6538,10 +6525,20 @@
       "license": "MIT"
     },
     "node_modules/js-yaml": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.0.tgz",
-      "integrity": "sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==",
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.2.0.tgz",
+      "integrity": "sha512-ePWsvanv0DWuDRsW8dnt+R4jQ31SCRCQ7hhNcPXZPsoBZiemuZNYGf7adZdqX2D86j6rvKp3RpCxVTSb8WQlOw==",
       "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/puzrin"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/nodeca"
+        }
+      ],
       "license": "MIT",
       "dependencies": {
         "argparse": "^2.0.1"
@@ -6752,7 +6749,9 @@
       }
     },
     "node_modules/long": {
-      "version": "5.2.3",
+      "version": "5.3.2",
+      "resolved": "https://registry.npmjs.org/long/-/long-5.3.2.tgz",
+      "integrity": "sha512-mNAgZ1GmyNhD7AuqnTG3/VQ26o760+ZYBPKjPvugO8+nLbYfX6TVpJPseBvopbdY+qpZ/lKUnmEc1LeZYS3QAA==",
       "license": "Apache-2.0"
     },
     "node_modules/lru-cache": {
@@ -6920,10 +6919,11 @@
       "license": "MIT"
     },
     "node_modules/minimatch": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
-      "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
+      "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
       "dev": true,
+      "license": "ISC",
       "dependencies": {
         "brace-expansion": "^1.1.7"
       },
@@ -7144,9 +7144,9 @@
       }
     },
     "node_modules/object-inspect": {
-      "version": "1.13.2",
-      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.2.tgz",
-      "integrity": "sha512-IRZSRuzJiynemAXPYtPe5BoI/RESNYR7TYm50MC5Mqbd3Jmw5y790sErYw3V6SryFJD64b74qQQs9wn5Bg/k3g==",
+      "version": "1.13.4",
+      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.4.tgz",
+      "integrity": "sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==",
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -7344,9 +7344,9 @@
       "license": "MIT"
     },
     "node_modules/path-to-regexp": {
-      "version": "0.1.12",
-      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.12.tgz",
-      "integrity": "sha512-RA1GjUVMnvYFxuqovrEqZoxxW5NUZqbwKtYz/Tt7nXerk0LbLblQmrsgdeOxV5SFHf0UDggjS/bSeOZwt1pmEQ==",
+      "version": "0.1.13",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.13.tgz",
+      "integrity": "sha512-A/AGNMFN3c8bOlvV9RreMdrv7jsmF9XIfDeCd87+I8RNg6s78BhJxMu69NEMHBSJFxKidViTEdruRwEk/WIKqA==",
       "license": "MIT"
     },
     "node_modules/pg-int8": {
@@ -7388,10 +7388,11 @@
       "license": "ISC"
     },
     "node_modules/picomatch": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
-      "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.2.tgz",
+      "integrity": "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=8.6"
       },
@@ -7645,24 +7646,24 @@
       }
     },
     "node_modules/protobufjs": {
-      "version": "7.4.0",
-      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.4.0.tgz",
-      "integrity": "sha512-mRUWCc3KUU4w1jU8sGxICXH/gNS94DvI1gxqDvBzhj1JpcsimQkYiOJfwsPUykUI5ZaspFbSgmBLER8IrQ3tqw==",
+      "version": "7.6.2",
+      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.6.2.tgz",
+      "integrity": "sha512-N9EiLovGEQOJSPF26Ij7qUGvahfEnq0eeYZ02aigIedkmz1qZSwjnP9SBITHJuF/6MYbIW4HDN8zdYjsjqJKXQ==",
       "hasInstallScript": true,
       "license": "BSD-3-Clause",
       "dependencies": {
         "@protobufjs/aspromise": "^1.1.2",
         "@protobufjs/base64": "^1.1.2",
-        "@protobufjs/codegen": "^2.0.4",
-        "@protobufjs/eventemitter": "^1.1.0",
-        "@protobufjs/fetch": "^1.1.0",
+        "@protobufjs/codegen": "^2.0.5",
+        "@protobufjs/eventemitter": "^1.1.1",
+        "@protobufjs/fetch": "^1.1.1",
         "@protobufjs/float": "^1.0.2",
-        "@protobufjs/inquire": "^1.1.0",
+        "@protobufjs/inquire": "^1.1.2",
         "@protobufjs/path": "^1.1.2",
         "@protobufjs/pool": "^1.1.0",
-        "@protobufjs/utf8": "^1.1.0",
+        "@protobufjs/utf8": "^1.1.1",
         "@types/node": ">=13.7.0",
-        "long": "^5.0.0"
+        "long": "^5.3.2"
       },
       "engines": {
         "node": ">=12.0.0"
@@ -7681,8 +7682,13 @@
       }
     },
     "node_modules/proxy-from-env": {
-      "version": "1.1.0",
-      "license": "MIT"
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-2.1.0.tgz",
+      "integrity": "sha512-cJ+oHTW1VAEa8cJslgmUZrc+sjRKgAKl3Zyse6+PV38hZe/V6Z14TbCuXcan9F9ghlz4QrFr2c92TNF82UkYHA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      }
     },
     "node_modules/psl": {
       "version": "1.10.0",
@@ -7730,12 +7736,12 @@
       "license": "MIT"
     },
     "node_modules/qs": {
-      "version": "6.13.0",
-      "resolved": "https://registry.npmjs.org/qs/-/qs-6.13.0.tgz",
-      "integrity": "sha512-+38qI9SOr8tfZ4QmJNplMUxqjbe7LKvvZgWdExBOmd+egZTtjLB67Gu0HRX3u/XOq7UU2Nx6nsjvS16Z9uwfpg==",
+      "version": "6.15.2",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.2.tgz",
+      "integrity": "sha512-Rzq0KEyX/w/tEybncDgdkZrJgVUsUMk3xjh3t5bv3S1HTAtg+uOYt72+ZfwiQwKdysThkTBdL/rTi6HDmX9Ddw==",
       "license": "BSD-3-Clause",
       "dependencies": {
-        "side-channel": "^1.0.6"
+        "side-channel": "^1.1.0"
       },
       "engines": {
         "node": ">=0.6"
@@ -7782,16 +7788,45 @@
       }
     },
     "node_modules/raw-body": {
-      "version": "2.5.2",
-      "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-2.5.2.tgz",
-      "integrity": "sha512-8zGqypfENjCIqGhgXToC8aB2r7YrBX+AQAfIPs/Mlk+BtPTztOvTS01NRW/3Eh60J+a48lt8qsCzirQ6loCVfA==",
+      "version": "2.5.3",
+      "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-2.5.3.tgz",
+      "integrity": "sha512-s4VSOf6yN0rvbRZGxs8Om5CWj6seneMwK3oDb4lWDH0UPhWcxwOWw5+qk24bxq87szX1ydrwylIOp2uG1ojUpA==",
       "license": "MIT",
       "dependencies": {
-        "bytes": "3.1.2",
-        "http-errors": "2.0.0",
-        "iconv-lite": "0.4.24",
-        "unpipe": "1.0.0"
+        "bytes": "~3.1.2",
+        "http-errors": "~2.0.1",
+        "iconv-lite": "~0.4.24",
+        "unpipe": "~1.0.0"
       },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/raw-body/node_modules/http-errors": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.1.tgz",
+      "integrity": "sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ==",
+      "license": "MIT",
+      "dependencies": {
+        "depd": "~2.0.0",
+        "inherits": "~2.0.4",
+        "setprototypeof": "~1.2.0",
+        "statuses": "~2.0.2",
+        "toidentifier": "~1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/raw-body/node_modules/statuses": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.2.tgz",
+      "integrity": "sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw==",
+      "license": "MIT",
       "engines": {
         "node": ">= 0.8"
       }
@@ -7994,15 +8029,6 @@
         "queue-microtask": "^1.2.2"
       }
     },
-    "node_modules/rxjs": {
-      "version": "7.8.1",
-      "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-7.8.1.tgz",
-      "integrity": "sha512-AA3TVj+0A2iuIoQkWEK/tqFjBq2j+6PO6Y0zJcvzLAFhEFIO3HL0vls9hWLncZbAAbK0mar7oZ4V079I/qPMxg==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "tslib": "^2.1.0"
-      }
-    },
     "node_modules/safe-buffer": {
       "version": "5.2.1",
       "funding": [
@@ -8114,23 +8140,6 @@
         "node": ">= 0.8.0"
       }
     },
-    "node_modules/set-function-length": {
-      "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/set-function-length/-/set-function-length-1.2.2.tgz",
-      "integrity": "sha512-pgRc4hJ4/sNjWCSS9AmnS40x3bNMDTknHgL5UaMBTMyJnU90EgWh1Rz+MC9eFu4BuN/UwZjKQuY/1v3rM7HMfg==",
-      "license": "MIT",
-      "dependencies": {
-        "define-data-property": "^1.1.4",
-        "es-errors": "^1.3.0",
-        "function-bind": "^1.1.2",
-        "get-intrinsic": "^1.2.4",
-        "gopd": "^1.0.1",
-        "has-property-descriptors": "^1.0.2"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      }
-    },
     "node_modules/setprototypeof": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.2.0.tgz",
@@ -8165,15 +8174,69 @@
       "license": "BSD-2-Clause"
     },
     "node_modules/side-channel": {
-      "version": "1.0.6",
-      "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.0.6.tgz",
-      "integrity": "sha512-fDW/EZ6Q9RiO8eFG8Hj+7u/oW+XrPTIChwCOM2+th2A6OblDtYYIpve9m+KvI9Z4C9qSEXlaGR6bTEYHReuglA==",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.1.0.tgz",
+      "integrity": "sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw==",
       "license": "MIT",
       "dependencies": {
-        "call-bind": "^1.0.7",
         "es-errors": "^1.3.0",
-        "get-intrinsic": "^1.2.4",
-        "object-inspect": "^1.13.1"
+        "object-inspect": "^1.13.3",
+        "side-channel-list": "^1.0.0",
+        "side-channel-map": "^1.0.1",
+        "side-channel-weakmap": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-list": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.1.tgz",
+      "integrity": "sha512-mjn/0bi/oUURjc5Xl7IaWi/OJJJumuoJFQJfDDyO46+hBWsfaVM65TBHq2eoZBhzl9EchxOijpkbRC8SVBQU0w==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "object-inspect": "^1.13.4"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-map": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/side-channel-map/-/side-channel-map-1.0.1.tgz",
+      "integrity": "sha512-VCjCNfgMsby3tTdo02nbjtM/ewra6jPHmpThenkTYh8pG9ucZ/1P8So4u4FGBek/BjpOVsDCMoLA/iuBKIFXRA==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.5",
+        "object-inspect": "^1.13.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-weakmap": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/side-channel-weakmap/-/side-channel-weakmap-1.0.2.tgz",
+      "integrity": "sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.5",
+        "object-inspect": "^1.13.3",
+        "side-channel-map": "^1.0.1"
       },
       "engines": {
         "node": ">= 0.4"
@@ -8624,7 +8687,6 @@
     "node_modules/ts-node": {
       "version": "10.9.2",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@cspotcode/source-map-support": "^0.8.0",
         "@tsconfig/node10": "^1.0.7",
@@ -8678,7 +8740,8 @@
     "node_modules/tslib": {
       "version": "2.6.2",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
-      "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
+      "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q==",
+      "dev": true
     },
     "node_modules/tunnel-agent": {
       "version": "0.6.0",
@@ -8731,7 +8794,6 @@
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.7.3.tgz",
       "integrity": "sha512-84MVSjMEHP+FQRPy3pX9sTVV/INIex71s9TL2Gm5FG/WG1SqXeKyZ0k7/blY/4FdOzI12CBy1vGc4og/eus0fw==",
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -8799,7 +8861,6 @@
       "integrity": "sha512-Wy+/sdEH9kI3w9civgACwabHbKl+qIOu0uFZ9IMKzX3Jpv9og0ZBJrZExGrPpFAY7rWsXuxs5e7CPPP17A4eYA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.21.0",
         "@typescript-eslint/types": "8.21.0",
@@ -8989,9 +9050,9 @@
       }
     },
     "node_modules/valibot": {
-      "version": "0.37.0",
-      "resolved": "https://registry.npmjs.org/valibot/-/valibot-0.37.0.tgz",
-      "integrity": "sha512-FQz52I8RXgFgOHym3XHYSREbNtkgSjF9prvMFH1nBsRyfL6SfCzoT1GuSDTlbsuPubM7/6Kbw0ZMQb8A+V+VsQ==",
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/valibot/-/valibot-1.4.1.tgz",
+      "integrity": "sha512-klCmFTz2jeDluy9RwX+F884TCiogtdBJ/YaxSx1EOBYXa3NXNWj8kR1jjN8rzluwojJVWWaHJ4r1U5LfICnM3g==",
       "license": "MIT",
       "peerDependencies": {
         "typescript": ">=5"
@@ -9127,7 +9188,6 @@
       "resolved": "https://registry.npmjs.org/ws/-/ws-7.5.10.tgz",
       "integrity": "sha512-+dbF1tHwZpXcbOJdVOkzLDxZP1ailvSxM6ZweXTegylPny803bFhA+vqBYw4s31NSAk4S2Qz+AKXK9a4wkdjcQ==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=8.3.0"
       },

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,7 @@
         "@cosmjs/json-rpc": "^0.32.4",
         "@cosmjs/stargate": "^0.32.4",
         "@cosmjs/tendermint-rpc": "^0.32.4",
-        "@initia/initia.js": "^1.0.0",
+        "@initia/initia.js": "^1.1.0",
         "@initia/initia.proto": "^0.2.4",
         "@sentry/node": "^8.51.0",
         "@sentry/profiling-node": "^8.51.0",

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "@cosmjs/json-rpc": "^0.32.4",
     "@cosmjs/stargate": "^0.32.4",
     "@cosmjs/tendermint-rpc": "^0.32.4",
-    "@initia/initia.js": "^1.0.0",
+    "@initia/initia.js": "^1.1.0",
     "@initia/initia.proto": "^0.2.4",
     "@sentry/node": "^8.51.0",
     "@sentry/profiling-node": "^8.51.0",

--- a/src/lib/restClient.spec.ts
+++ b/src/lib/restClient.spec.ts
@@ -150,4 +150,14 @@ describe('RESTClient', () => {
     expect(res.channel.state).toBe(State.UNRECOGNIZED)
     expect(res.channel.ordering).toBe(Order.UNRECOGNIZED)
   })
+
+  it('preserves zero-value enum members instead of coercing to UNRECOGNIZED', async () => {
+    mockChannel('STATE_UNINITIALIZED_UNSPECIFIED', 'ORDER_NONE_UNSPECIFIED')
+
+    const client = new RESTClient(mockRestUris)
+    const res = await client.ibc.channel('transfer', 'channel-0')
+
+    expect(res.channel.state).toBe(State.STATE_UNINITIALIZED_UNSPECIFIED)
+    expect(res.channel.ordering).toBe(Order.ORDER_NONE_UNSPECIFIED)
+  })
 })

--- a/src/lib/restClient.spec.ts
+++ b/src/lib/restClient.spec.ts
@@ -1,4 +1,5 @@
 import nock from 'nock'
+import { Order, State } from '@initia/initia.proto/ibc/core/channel/v1/channel'
 import { RESTClient } from './restClient'
 import { logger } from './logger'
 
@@ -80,5 +81,73 @@ describe('RESTClient', () => {
     )
 
     expect(result.minimum_gas_price).toBe('0.03uinit')
+  })
+
+  const mockChannel = (state: string, ordering: string) =>
+    nock(mockRestUris[0])
+      .get('/ibc/core/channel/v1/channels/channel-0/ports/transfer')
+      .reply(200, {
+        channel: {
+          state,
+          ordering,
+          counterparty: { port_id: 'transfer', channel_id: 'channel-1' },
+          connection_hops: ['connection-0'],
+          version: 'ics20-1',
+        },
+        proof: null,
+        proof_height: { revision_number: 0, revision_height: 100 },
+      })
+
+  // Covers every channel state the relayer branches on (wallet.ts / index.ts
+  // compare against STATE_CLOSED / STATE_INIT / STATE_TRYOPEN), so the
+  // string→enum conversion stays locked against future refactors.
+  it.each([
+    ['STATE_INIT', State.STATE_INIT],
+    ['STATE_TRYOPEN', State.STATE_TRYOPEN],
+    ['STATE_OPEN', State.STATE_OPEN],
+    ['STATE_CLOSED', State.STATE_CLOSED],
+  ])('maps channel state %s to the proto enum', async (raw, expected) => {
+    mockChannel(raw, 'ORDER_UNORDERED')
+
+    const client = new RESTClient(mockRestUris)
+    const res = await client.ibc.channel('transfer', 'channel-0')
+
+    expect(res.channel.state).toBe(expected)
+  })
+
+  it.each([
+    ['ORDER_UNORDERED', Order.ORDER_UNORDERED],
+    ['ORDER_ORDERED', Order.ORDER_ORDERED],
+  ])('maps channel ordering %s to the proto enum', async (raw, expected) => {
+    mockChannel('STATE_OPEN', raw)
+
+    const client = new RESTClient(mockRestUris)
+    const res = await client.ibc.channel('transfer', 'channel-0')
+
+    expect(res.channel.ordering).toBe(expected)
+  })
+
+  it('passes counterparty, connection_hops and version through unchanged', async () => {
+    mockChannel('STATE_OPEN', 'ORDER_UNORDERED')
+
+    const client = new RESTClient(mockRestUris)
+    const res = await client.ibc.channel('transfer', 'channel-0')
+
+    expect(res.channel.version).toBe('ics20-1')
+    expect(res.channel.connection_hops).toEqual(['connection-0'])
+    expect(res.channel.counterparty).toEqual({
+      port_id: 'transfer',
+      channel_id: 'channel-1',
+    })
+  })
+
+  it('falls back to UNRECOGNIZED for unknown channel state/ordering', async () => {
+    mockChannel('STATE_GARBAGE', 'ORDER_GARBAGE')
+
+    const client = new RESTClient(mockRestUris)
+    const res = await client.ibc.channel('transfer', 'channel-0')
+
+    expect(res.channel.state).toBe(State.UNRECOGNIZED)
+    expect(res.channel.ordering).toBe(Order.UNRECOGNIZED)
   })
 })

--- a/src/lib/restClient.ts
+++ b/src/lib/restClient.ts
@@ -1,6 +1,5 @@
 import {
   APIRequester,
-  Channel,
   IbcAPI as IbcAPI_,
   RESTClientConfig,
   RESTClient as RESTClient_,
@@ -240,7 +239,19 @@ class IbcAPI extends IbcAPI_ {
 }
 
 interface ChannelResponse {
-  channel: Channel.Data
+  // initia.js@1.1.0 changed `Channel.Data.state`/`ordering` to `string`. We keep
+  // proto enums here so downstream comparisons (e.g. `=== State.STATE_CLOSED`)
+  // stay type-safe; the string→enum conversion happens in `channel()` above.
+  channel: {
+    state: State
+    ordering: Order
+    counterparty?: {
+      port_id: string
+      channel_id: string
+    }
+    connection_hops: string[]
+    version: string
+  }
   proof: null | string
   proof_height: {
     revision_number: number

--- a/src/lib/restClient.ts
+++ b/src/lib/restClient.ts
@@ -195,9 +195,9 @@ class IbcAPI extends IbcAPI_ {
     )
 
     const state =
-      State[rawRes.channel.state as keyof typeof State] || State.UNRECOGNIZED
+      State[rawRes.channel.state as keyof typeof State] ?? State.UNRECOGNIZED
     const ordering =
-      Order[rawRes.channel.ordering as keyof typeof Order] || Order.UNRECOGNIZED
+      Order[rawRes.channel.ordering as keyof typeof Order] ?? Order.UNRECOGNIZED
 
     return {
       channel: {

--- a/src/msgs/channelOpenTry.spec.ts
+++ b/src/msgs/channelOpenTry.spec.ts
@@ -1,0 +1,44 @@
+import { Order, State } from '@initia/initia.proto/ibc/core/channel/v1/channel'
+import { Height } from 'cosmjs-types/ibc/core/client/v1/client'
+
+jest.mock('src/lib/proof', () => ({
+  getChannelProof: jest.fn().mockResolvedValue('proof-base64'),
+}))
+
+import { generateMsgChannelOpenTry } from './channelOpenTry'
+import { ChainWorker } from 'src/workers/chain'
+
+describe('generateMsgChannelOpenTry', () => {
+  it('builds an OpenTry channel with TRYOPEN state, passthrough ordering and upgrade_sequence 0', async () => {
+    const srcChain = {
+      rest: {
+        ibc: {
+          channel: jest.fn().mockResolvedValue({
+            channel: { ordering: Order.ORDER_UNORDERED, version: 'ics20-1' },
+          }),
+        },
+      },
+    } as unknown as ChainWorker
+
+    const height = Height.fromPartial({
+      revisionNumber: 1n,
+      revisionHeight: 100n,
+    })
+
+    const msg = await generateMsgChannelOpenTry(
+      srcChain,
+      'transfer',
+      'channel-0',
+      'connection-1',
+      'transfer',
+      height,
+      'init1executor'
+    )
+
+    expect(msg.channel?.state).toBe(State.STATE_TRYOPEN)
+    expect(msg.channel?.ordering).toBe(Order.ORDER_UNORDERED)
+    expect(msg.channel?.upgrade_sequence).toBe(0)
+    expect(msg.channel?.connection_hops).toEqual(['connection-1'])
+    expect(msg.counterparty_version).toBe('ics20-1')
+  })
+})

--- a/src/msgs/channelOpenTry.ts
+++ b/src/msgs/channelOpenTry.ts
@@ -1,5 +1,6 @@
-import { Channel, ChannelCounterparty, State } from '@initia/initia.js'
+import { Channel, ChannelCounterparty } from '@initia/initia.js'
 import { MsgChannelOpenTry } from '@initia/initia.js'
+import { State } from '@initia/initia.proto/ibc/core/channel/v1/channel'
 import { Height } from 'cosmjs-types/ibc/core/client/v1/client'
 import { getChannelProof } from 'src/lib/proof'
 import { ChainWorker } from 'src/workers/chain'
@@ -23,7 +24,8 @@ export async function generateMsgChannelOpenTry(
     ordering,
     new ChannelCounterparty(srcPortId, srcChannelId),
     [dstConnectionId],
-    version
+    version,
+    0 // upgrade_sequence: 0 for a freshly opened channel (initia.js@1.1.0)
   )
 
   return new MsgChannelOpenTry(

--- a/src/test/testSetup.ts
+++ b/src/test/testSetup.ts
@@ -7,8 +7,10 @@ import { initDBConnection } from 'src/db'
 import { RestMockServer } from './mockServer/rest'
 import { http, RequestHandler, HttpResponse } from 'msw'
 import { setupServer } from 'msw/node'
+import type { SetupServerApi } from 'msw/node'
 
 export let mockServers: { rest: RestMockServer }[] = []
+let server: SetupServerApi | undefined
 
 const firstUri = (uri: string | string[]): string => {
   if (Array.isArray(uri)) {
@@ -18,6 +20,11 @@ const firstUri = (uri: string | string[]): string => {
     return uri[0]
   }
   return uri
+}
+
+const shouldBypassUnhandledRequest = (request: Request): boolean => {
+  const hostname = new URL(request.url).hostname
+  return /^(doi|moro|rene)-(rest|rpc)-\d+\.com$/.test(hostname)
 }
 
 const setup = () => {
@@ -126,7 +133,21 @@ const setup = () => {
     return { rest: restServer }
   })
 
-  setupServer(...handlers).listen()
+  server = setupServer(...handlers)
+  server.listen({
+    onUnhandledRequest(request, print) {
+      if (shouldBypassUnhandledRequest(request)) {
+        return
+      }
+
+      print.warning()
+    },
+  })
 }
 
 beforeAll(() => setup())
+
+afterAll(() => {
+  server?.close()
+  server = undefined
+})

--- a/src/workers/accountSequence.spec.ts
+++ b/src/workers/accountSequence.spec.ts
@@ -1,0 +1,83 @@
+import {
+  AccountSequenceTracker,
+  parseExpectedSequenceFromRawLog,
+} from './accountSequence'
+
+describe('parseExpectedSequenceFromRawLog', () => {
+  test('extracts expected sequence from account sequence mismatch raw log', () => {
+    expect(
+      parseExpectedSequenceFromRawLog(
+        'account sequence mismatch, expected 42, got 41'
+      )
+    ).toBe(42)
+  })
+
+  test('returns undefined for unrelated tx errors', () => {
+    expect(parseExpectedSequenceFromRawLog('packet already received')).toBe(
+      undefined
+    )
+  })
+})
+
+describe('AccountSequenceTracker', () => {
+  test('initializes once and increments locally after success without extra query', async () => {
+    let calls = 0
+    const tracker = new AccountSequenceTracker(async () => {
+      calls++
+      return { sequence: 10, accountNumber: 7 }
+    })
+
+    await tracker.ensureInitialized()
+    tracker.markBroadcastSuccess()
+
+    expect(tracker.sequence()).toBe(11)
+    expect(tracker.accountNumber()).toBe(7)
+    expect(calls).toBe(1)
+  })
+
+  test('uses parsed expected sequence on sequence mismatch without extra query', async () => {
+    let calls = 0
+    const tracker = new AccountSequenceTracker(async () => {
+      calls++
+      return { sequence: 10, accountNumber: 7 }
+    })
+
+    await tracker.ensureInitialized()
+    await tracker.reconcileTxError(
+      'account sequence mismatch, expected 12, got 10'
+    )
+
+    expect(tracker.sequence()).toBe(12)
+    expect(calls).toBe(1)
+  })
+
+  test('refreshes from chain for non-sequence tx error', async () => {
+    let nextSequence = 10
+    let calls = 0
+    const tracker = new AccountSequenceTracker(async () => {
+      calls++
+      return { sequence: nextSequence, accountNumber: 7 }
+    })
+
+    await tracker.ensureInitialized()
+    nextSequence = 11
+    await tracker.reconcileTxError('packet already received')
+
+    expect(tracker.sequence()).toBe(11)
+    expect(calls).toBe(2)
+  })
+
+  test('refreshes from chain for broadcast exception after signed tx', async () => {
+    let nextSequence = 10
+    const tracker = new AccountSequenceTracker(async () => ({
+      sequence: nextSequence,
+      accountNumber: 7,
+    }))
+
+    await tracker.ensureInitialized()
+    nextSequence = 11
+    await tracker.reconcileBroadcastException()
+
+    expect(tracker.sequence()).toBe(11)
+  })
+})

--- a/src/workers/accountSequence.ts
+++ b/src/workers/accountSequence.ts
@@ -1,0 +1,82 @@
+export interface AccountSequenceSnapshot {
+  sequence: number
+  accountNumber: number
+}
+
+export type FetchAccountSequence = () => Promise<AccountSequenceSnapshot>
+
+export function parseExpectedSequenceFromRawLog(
+  rawLog?: string
+): number | undefined {
+  if (!rawLog) {
+    return undefined
+  }
+
+  const match = rawLog.match(/account sequence mismatch.*expected\s+(\d+)/i)
+  if (!match) {
+    return undefined
+  }
+
+  const parsed = Number(match[1])
+  return Number.isFinite(parsed) ? parsed : undefined
+}
+
+export class AccountSequenceTracker {
+  private cachedSequence?: number
+  private cachedAccountNumber?: number
+
+  public constructor(
+    private readonly fetchAccountSequence: FetchAccountSequence
+  ) {}
+
+  public async ensureInitialized(): Promise<void> {
+    if (
+      this.cachedSequence !== undefined &&
+      this.cachedAccountNumber !== undefined
+    ) {
+      return
+    }
+
+    await this.refresh()
+  }
+
+  public sequence(): number {
+    if (this.cachedSequence === undefined) {
+      throw new Error('Account sequence is not initialized')
+    }
+
+    return this.cachedSequence
+  }
+
+  public accountNumber(): number {
+    if (this.cachedAccountNumber === undefined) {
+      throw new Error('Account number is not initialized')
+    }
+
+    return this.cachedAccountNumber
+  }
+
+  public markBroadcastSuccess(): void {
+    this.cachedSequence = this.sequence() + 1
+  }
+
+  public async reconcileTxError(rawLog?: string): Promise<void> {
+    const expectedSequence = parseExpectedSequenceFromRawLog(rawLog)
+    if (expectedSequence !== undefined) {
+      this.cachedSequence = expectedSequence
+      return
+    }
+
+    await this.refresh()
+  }
+
+  public async reconcileBroadcastException(): Promise<void> {
+    await this.refresh()
+  }
+
+  private async refresh(): Promise<void> {
+    const snapshot = await this.fetchAccountSequence()
+    this.cachedSequence = snapshot.sequence
+    this.cachedAccountNumber = snapshot.accountNumber
+  }
+}

--- a/src/workers/wallet.ts
+++ b/src/workers/wallet.ts
@@ -22,10 +22,10 @@ import { State } from '@initia/initia.proto/ibc/core/channel/v1/channel'
 import { PacketFee } from 'src/lib/config'
 import { ClientController } from 'src/db/controller/client'
 import { captureException } from 'src/lib/sentry'
+import { AccountSequenceTracker } from './accountSequence'
 
 export class WalletWorker {
-  private sequence?: number
-  private accountNumber?: number
+  private sequenceTracker: AccountSequenceTracker
   private logger: Logger
   private errorTracker = new Map<string, number>()
   public lastExecutionTimestamp: Date
@@ -37,13 +37,23 @@ export class WalletWorker {
     private maxHandlePacket: number,
     public wallet: Wallet,
     public gasTokenBalance: bigint,
-    public packetFilter?: PacketFilter
+    public packetFilter?: PacketFilter,
+    private options: { autoStart?: boolean } = {}
   ) {
     this.logger = createLoggerWithPrefix(
       `<Wallet(${this.chain.chainId}-${this.address()})>`
     )
+    this.sequenceTracker = new AccountSequenceTracker(async () => {
+      const accInfo = await this.wallet.rest.auth.accountInfo(this.address())
+      return {
+        sequence: accInfo.getSequenceNumber(),
+        accountNumber: accInfo.getAccountNumber(),
+      }
+    })
     this.lastExecutionTimestamp = new Date()
-    void this.run()
+    if (this.options.autoStart !== false) {
+      void this.run()
+    }
   }
 
   public stop() {
@@ -78,18 +88,76 @@ export class WalletWorker {
     }
   }
 
-  private async initAccInfo() {
-    const accInfo = await this.wallet.rest.auth.accountInfo(this.address())
-    this.sequence = accInfo.getSequenceNumber()
-    this.accountNumber = accInfo.getAccountNumber()
-  }
-
   private async checkAndStoreError(code: string, error: Error) {
     const now = Date.now()
     const lastErrorTime = this.errorTracker.get(code) ?? 0
     if (now - lastErrorTime > 10 * 60 * 1000) {
       this.errorTracker.set(code, now)
       await captureException(error)
+    }
+  }
+
+  private async signAndBroadcast(
+    msgs: Parameters<Wallet['createAndSignTx']>[0]['msgs']
+  ): Promise<void> {
+    await this.sequenceTracker.ensureInitialized()
+
+    const signedSequence = this.sequenceTracker.sequence()
+    const signedTx = await this.wallet.createAndSignTx({
+      msgs,
+      sequence: signedSequence,
+      accountNumber: this.sequenceTracker.accountNumber(),
+    })
+
+    let reconciliationAttempted = false
+
+    try {
+      const result = await this.wallet.rest.tx.broadcast(signedTx)
+
+      if (isTxError(result)) {
+        const txError = new Error(
+          `Tx failed. raw log - ${result.raw_log}, code - ${result.code}`
+        )
+
+        try {
+          reconciliationAttempted = true
+          await this.sequenceTracker.reconcileTxError(result.raw_log)
+          this.logger.warn(
+            `Broadcast failed; reconciled account sequence. signedSequence=${signedSequence}, currentSequence=${this.sequenceTracker.sequence()}`
+          )
+        } catch (sequenceError) {
+          this.logger.error(
+            `Failed to reconcile account sequence: ${String(sequenceError)}`
+          )
+        }
+
+        await this.checkAndStoreError(result.code.toString(), txError)
+        this.logger.error(txError)
+        throw txError
+      }
+
+      this.logger.info(
+        `Handled msgs(${msgs.length}). txhash - ${result.txhash}`
+      )
+
+      this.sequenceTracker.markBroadcastSuccess()
+      this.lastExecutionTimestamp = new Date()
+    } catch (e) {
+      if (!reconciliationAttempted) {
+        try {
+          reconciliationAttempted = true
+          await this.sequenceTracker.reconcileBroadcastException()
+          this.logger.warn(
+            `Broadcast failed; reconciled account sequence. signedSequence=${signedSequence}, currentSequence=${this.sequenceTracker.sequence()}`
+          )
+        } catch (sequenceError) {
+          this.logger.error(
+            `Failed to reconcile account sequence: ${String(sequenceError)}`
+          )
+        }
+      }
+
+      throw e
     }
   }
 
@@ -394,55 +462,12 @@ export class WalletWorker {
         return
       }
 
-      // init sequence
-      if (!this.sequence) {
-        await this.initAccInfo()
-        if (this.sequence === undefined) {
-          throw Error('Failed to update sequence number')
-        }
-      }
-
-      const signedTx = await this.wallet.createAndSignTx({
-        msgs,
-        sequence: this.sequence,
-        accountNumber: this.accountNumber,
-      })
-
-      const result = await this.wallet.rest.tx.broadcast(signedTx)
-
-      if (isTxError(result)) {
-        if (result.raw_log.startsWith('account sequence mismatch')) {
-          try {
-            const expected = result.raw_log.split(', ')[1]
-            this.sequence = Number(expected.split(' ')[1])
-            this.logger.info(`update sequence`)
-          } catch {
-            this.logger.warn(`error to parse sequence`)
-          }
-        }
-
-        const error = new Error(
-          `Tx failed. raw log - ${result.raw_log}, code - ${result.code}`
-        )
-
-        await this.checkAndStoreError(result.code.toString(), error)
-        this.logger.error(error)
-        throw error
-      }
-
-      this.logger.info(
-        `Handled msgs(${msgs.length}). txhash - ${result.txhash}`
-      )
-
-      this.sequence++
-      this.lastExecutionTimestamp = new Date()
+      await this.signAndBroadcast(msgs)
     } catch (e) {
       // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
       if (e?.response?.data) {
         // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
         this.logger.error(e.response.data)
-        // tmp: refresh sequence when got error. TODO: parse sequence from error
-        await this.initAccInfo()
       } else {
         this.logger.error(e)
       }

--- a/src/workers/walletSequence.spec.ts
+++ b/src/workers/walletSequence.spec.ts
@@ -1,0 +1,222 @@
+const mockLogger = {
+  debug: jest.fn(),
+  error: jest.fn(),
+  info: jest.fn(),
+  warn: jest.fn(),
+}
+
+jest.mock('src/lib/logger', () => ({
+  createLoggerWithPrefix: () => ({
+    debug: mockLogger.debug,
+    error: mockLogger.error,
+    info: mockLogger.info,
+    warn: mockLogger.warn,
+  }),
+  debug: mockLogger.debug,
+  error: mockLogger.error,
+  info: mockLogger.info,
+  logger: {
+    debug: mockLogger.debug,
+    error: mockLogger.error,
+    info: mockLogger.info,
+    warn: mockLogger.warn,
+  },
+  warn: mockLogger.warn,
+}))
+
+import { bech32 } from 'bech32'
+import { WalletWorker } from './wallet'
+import { ChainWorker } from './chain'
+import { WorkerController } from '.'
+import { Wallet } from '@initia/initia.js'
+
+interface TestAccountInfo {
+  getSequenceNumber(): number
+  getAccountNumber(): number
+}
+
+type AccountInfoResponse = TestAccountInfo | Error
+
+interface TestWalletWorker {
+  signAndBroadcast(msgs: unknown[]): Promise<void>
+  sequenceTracker: {
+    sequence(): number
+  }
+}
+
+function accountInfo(sequence: number, accountNumber = 7): TestAccountInfo {
+  return {
+    getSequenceNumber: () => sequence,
+    getAccountNumber: () => accountNumber,
+  }
+}
+
+function makeAddress(): string {
+  return bech32.encode('init', bech32.toWords(Buffer.alloc(20, 1)))
+}
+
+function makeWorker(options: {
+  accountInfoResponses: AccountInfoResponse[]
+  broadcastResult?: unknown
+  broadcastError?: Error
+}): {
+  worker: TestWalletWorker
+  authAccountInfo: jest.Mock
+  broadcast: jest.Mock
+  createAndSignTx: jest.Mock
+} {
+  const authAccountInfo = jest
+    .fn()
+    .mockImplementation(() => {
+      const response = options.accountInfoResponses.shift()
+      if (response instanceof Error) {
+        return Promise.reject(response)
+      }
+
+      return Promise.resolve(response)
+    })
+  const broadcast = jest.fn()
+
+  if (options.broadcastError) {
+    broadcast.mockRejectedValue(options.broadcastError)
+  } else {
+    broadcast.mockResolvedValue(options.broadcastResult)
+  }
+
+  const createAndSignTx = jest.fn(async ({ msgs }) => ({
+    body: { messages: msgs },
+  }))
+
+  const wallet = {
+    key: { accAddress: makeAddress() },
+    rest: {
+      auth: { accountInfo: authAccountInfo },
+      tx: { broadcast },
+    },
+    createAndSignTx,
+  } as unknown as Wallet
+
+  const worker = new WalletWorker(
+    { chainId: 'l1', bech32Prefix: 'init' } as unknown as ChainWorker,
+    {} as WorkerController,
+    100,
+    wallet,
+    0n,
+    undefined,
+    { autoStart: false }
+  ) as unknown as TestWalletWorker
+
+  return {
+    worker,
+    authAccountInfo,
+    broadcast,
+    createAndSignTx,
+  }
+}
+
+describe('WalletWorker account sequence reconciliation', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+  })
+
+  test('does not query account info after successful broadcast beyond initial load', async () => {
+    const { worker, authAccountInfo, createAndSignTx } = makeWorker({
+      accountInfoResponses: [accountInfo(10)],
+      broadcastResult: {
+        txhash: 'hash',
+        raw_log: '',
+        gas_wanted: 1,
+        gas_used: 1,
+        height: 1,
+        logs: [],
+        timestamp: '',
+      },
+    })
+
+    await worker.signAndBroadcast([{}])
+
+    expect(createAndSignTx).toHaveBeenCalledWith({
+      msgs: [{}],
+      sequence: 10,
+      accountNumber: 7,
+    })
+    expect(worker.sequenceTracker.sequence()).toBe(11)
+    expect(authAccountInfo).toHaveBeenCalledTimes(1)
+  })
+
+  test('uses parsed expected sequence on sequence mismatch without extra query', async () => {
+    const { worker, authAccountInfo } = makeWorker({
+      accountInfoResponses: [accountInfo(10)],
+      broadcastResult: {
+        code: 32,
+        raw_log: 'account sequence mismatch, expected 12, got 10',
+        txhash: 'hash',
+      },
+    })
+
+    await expect(worker.signAndBroadcast([{}])).rejects.toThrow(
+      'Tx failed. raw log - account sequence mismatch, expected 12, got 10, code - 32'
+    )
+
+    expect(worker.sequenceTracker.sequence()).toBe(12)
+    expect(authAccountInfo).toHaveBeenCalledTimes(1)
+  })
+
+  test('refreshes account sequence after non-sequence tx error', async () => {
+    const { worker, authAccountInfo } = makeWorker({
+      accountInfoResponses: [accountInfo(10), accountInfo(11)],
+      broadcastResult: {
+        code: 2,
+        raw_log: 'packet already received',
+        txhash: 'hash',
+      },
+    })
+
+    await expect(worker.signAndBroadcast([{}])).rejects.toThrow(
+      'Tx failed. raw log - packet already received, code - 2'
+    )
+
+    expect(worker.sequenceTracker.sequence()).toBe(11)
+    expect(authAccountInfo).toHaveBeenCalledTimes(2)
+  })
+
+  test('refreshes account sequence after broadcast timeout exception', async () => {
+    const { worker, authAccountInfo } = makeWorker({
+      accountInfoResponses: [accountInfo(10), accountInfo(11)],
+      broadcastError: new Error(
+        'Transaction was not included in a block before timeout of 30000ms'
+      ),
+    })
+
+    await expect(worker.signAndBroadcast([{}])).rejects.toThrow(
+      'Transaction was not included in a block before timeout of 30000ms'
+    )
+
+    expect(worker.sequenceTracker.sequence()).toBe(11)
+    expect(authAccountInfo).toHaveBeenCalledTimes(2)
+    expect(mockLogger.warn).toHaveBeenCalledWith(
+      'Broadcast failed; reconciled account sequence. signedSequence=10, currentSequence=11'
+    )
+  })
+
+  test('does not retry sequence refresh when tx error reconciliation query fails', async () => {
+    const { worker, authAccountInfo } = makeWorker({
+      accountInfoResponses: [
+        accountInfo(10),
+        new Error('account info unavailable'),
+        accountInfo(11),
+      ],
+      broadcastResult: {
+        code: 2,
+        raw_log: 'packet already received',
+        txhash: 'hash',
+      },
+    })
+
+    await expect(worker.signAndBroadcast([{}])).rejects.toThrow(
+      'Tx failed. raw log - packet already received, code - 2'
+    )
+
+    expect(authAccountInfo).toHaveBeenCalledTimes(2)
+  })
+})


### PR DESCRIPTION
- Add `AccountSequenceTracker` to reconcile sequence on broadcast failure, recovering from `account sequence mismatch` without a restart
- bump initia.js

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Enhanced account sequence tracking with improved error recovery during transaction broadcasts.
  * Better handling of blockchain sequence mismatch scenarios.

* **Improvements**
  * Optimized IBC channel state and ordering handling.
  * Refined transaction error reconciliation logic.

* **Chores**
  * Updated `@initia/initia.js` dependency to v1.1.0.
  * Added comprehensive test coverage for sequence management and error scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->