### PR TITLE
fix: handle stale nonce error format for sequence reconciliation

### DIFF
--- a/src/workers/accountSequence.spec.ts
+++ b/src/workers/accountSequence.spec.ts
@@ -12,6 +12,14 @@ describe('parseExpectedSequenceFromRawLog', () => {
     ).toBe(42)
   })
 
+  test('extracts expected sequence from stale nonce raw log', () => {
+    expect(
+      parseExpectedSequenceFromRawLog(
+        'nonce 14299 is stale for sender init1ueyyepx649e67zjremxgfqvyn6fuyl2d3gnrl5 (expected >= 14300): incorrect account sequence, code - 32'
+      )
+    ).toBe(14300)
+  })
+
   test('returns undefined for unrelated tx errors', () => {
     expect(parseExpectedSequenceFromRawLog('packet already received')).toBe(
       undefined

--- a/src/workers/accountSequence.ts
+++ b/src/workers/accountSequence.ts
@@ -12,7 +12,9 @@ export function parseExpectedSequenceFromRawLog(
     return undefined
   }
 
-  const match = rawLog.match(/account sequence mismatch.*expected\s+(\d+)/i)
+  const match =
+    rawLog.match(/account sequence mismatch.*expected\s+(\d+)/i) ??
+    rawLog.match(/nonce\s+\d+\s+is\s+stale.*expected\s*>=\s*(\d+)/i)
   if (!match) {
     return undefined
   }


### PR DESCRIPTION
## Summary

Some chains report an account sequence mismatch using a different message format than the one the relayer currently parses:

```
nonce 14299 is stale for sender init1ueyyepx649e67zjremxgfqvyn6fuyl2d3gnrl5 (expected >= 14300): incorrect account sequence, code - 32
```

The existing parser in `parseExpectedSequenceFromRawLog` only matched `account sequence mismatch, expected M, got N`. For the stale-nonce format it returned `undefined`, causing `reconcileTxError` to fall back to an extra chain query (`refresh()`) to recover the sequence.

This adds a second pattern so the expected sequence (`14300`) is parsed directly from the stale-nonce format, reconciling the sequence without an extra account-info query — same as the existing fast path.

## Changes

- `parseExpectedSequenceFromRawLog`: also match `nonce N is stale ... (expected >= M)`.
- Added a unit test for the new format.

## Note

This PR only covers the stale-nonce sequence handling. Out-of-gas (code != 0, reverted-in-block) handling is being discussed separately and is not part of this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced error parsing logic to recognize additional error message formats, including stale nonce errors alongside sequence mismatch errors, improving account sequence detection capabilities and system reliability.

* **Tests**
  * Added test coverage for stale nonce error message parsing to validate correct sequence information extraction.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->