### PR TITLE
fix: retry with higher gas adjustment after out of gas error

### DIFF
--- a/src/workers/wallet.ts
+++ b/src/workers/wallet.ts
@@ -24,10 +24,26 @@ import { ClientController } from 'src/db/controller/client'
 import { captureException } from 'src/lib/sentry'
 import { AccountSequenceTracker } from './accountSequence'
 
+// initia.js default gas adjustment applied to the simulated gas.
+const BASE_GAS_ADJUSTMENT = 1.75
+// multiplier applied to the gas adjustment after an out of gas failure.
+const GAS_ADJUSTMENT_STEP = 1.2
+// upper bound to avoid unbounded fee growth on repeated failures.
+const MAX_GAS_ADJUSTMENT = 4
+
+export function isOutOfGasError(rawLog?: string): boolean {
+  if (!rawLog) {
+    return false
+  }
+
+  return /out of gas/i.test(rawLog)
+}
+
 export class WalletWorker {
   private sequenceTracker: AccountSequenceTracker
   private logger: Logger
   private errorTracker = new Map<string, number>()
+  private gasAdjustment = BASE_GAS_ADJUSTMENT
   public lastExecutionTimestamp: Date
   public stopped = false
 
@@ -107,6 +123,7 @@ export class WalletWorker {
       msgs,
       sequence: signedSequence,
       accountNumber: this.sequenceTracker.accountNumber(),
+      gasAdjustment: this.gasAdjustment,
     })
 
     let reconciliationAttempted = false
@@ -131,6 +148,16 @@ export class WalletWorker {
           )
         }
 
+        if (isOutOfGasError(result.raw_log)) {
+          this.gasAdjustment = Math.min(
+            this.gasAdjustment * GAS_ADJUSTMENT_STEP,
+            MAX_GAS_ADJUSTMENT
+          )
+          this.logger.warn(
+            `Tx ran out of gas; increased gasAdjustment to ${this.gasAdjustment} for retry`
+          )
+        }
+
         await this.checkAndStoreError(result.code.toString(), txError)
         this.logger.error(txError)
         throw txError
@@ -141,6 +168,7 @@ export class WalletWorker {
       )
 
       this.sequenceTracker.markBroadcastSuccess()
+      this.gasAdjustment = BASE_GAS_ADJUSTMENT
       this.lastExecutionTimestamp = new Date()
     } catch (e) {
       if (!reconciliationAttempted) {

--- a/src/workers/walletSequence.spec.ts
+++ b/src/workers/walletSequence.spec.ts
@@ -42,6 +42,7 @@ interface TestWalletWorker {
   sequenceTracker: {
     sequence(): number
   }
+  gasAdjustment: number
 }
 
 function accountInfo(sequence: number, accountNumber = 7): TestAccountInfo {
@@ -139,6 +140,7 @@ describe('WalletWorker account sequence reconciliation', () => {
       msgs: [{}],
       sequence: 10,
       accountNumber: 7,
+      gasAdjustment: 1.75,
     })
     expect(worker.sequenceTracker.sequence()).toBe(11)
     expect(authAccountInfo).toHaveBeenCalledTimes(1)
@@ -197,6 +199,57 @@ describe('WalletWorker account sequence reconciliation', () => {
     expect(mockLogger.warn).toHaveBeenCalledWith(
       'Broadcast failed; reconciled account sequence. signedSequence=10, currentSequence=11'
     )
+  })
+
+  test('increases gasAdjustment after an out of gas error', async () => {
+    const { worker, createAndSignTx } = makeWorker({
+      accountInfoResponses: [accountInfo(10), accountInfo(11)],
+      broadcastResult: {
+        code: 11,
+        raw_log:
+          'out of gas in location: ReadFlat; gasWanted: 1856904, gasUsed: 1857904: out of gas',
+        txhash: 'hash',
+      },
+    })
+
+    expect(worker.gasAdjustment).toBe(1.75)
+
+    await expect(worker.signAndBroadcast([{}])).rejects.toThrow('out of gas')
+
+    expect(createAndSignTx).toHaveBeenLastCalledWith({
+      msgs: [{}],
+      sequence: 10,
+      accountNumber: 7,
+      gasAdjustment: 1.75,
+    })
+    expect(worker.gasAdjustment).toBeCloseTo(2.1)
+  })
+
+  test('resets gasAdjustment after a successful broadcast', async () => {
+    const { worker, createAndSignTx } = makeWorker({
+      accountInfoResponses: [accountInfo(10)],
+      broadcastResult: {
+        txhash: 'hash',
+        raw_log: '',
+        gas_wanted: 1,
+        gas_used: 1,
+        height: 1,
+        logs: [],
+        timestamp: '',
+      },
+    })
+
+    worker.gasAdjustment = 3
+
+    await worker.signAndBroadcast([{}])
+
+    expect(createAndSignTx).toHaveBeenCalledWith({
+      msgs: [{}],
+      sequence: 10,
+      accountNumber: 7,
+      gasAdjustment: 3,
+    })
+    expect(worker.gasAdjustment).toBe(1.75)
   })
 
   test('does not retry sequence refresh when tx error reconciliation query fails', async () => {

--- a/src/workers/walletSequence.spec.ts
+++ b/src/workers/walletSequence.spec.ts
@@ -201,19 +201,30 @@ describe('WalletWorker account sequence reconciliation', () => {
     )
   })
 
-  test('increases gasAdjustment after an out of gas error', async () => {
-    const { worker, createAndSignTx } = makeWorker({
+  test('increases gasAdjustment after an out of gas error and uses it on retry', async () => {
+    const successResult = {
+      txhash: 'retry-hash',
+      raw_log: '',
+      gas_wanted: 1,
+      gas_used: 1,
+      height: 1,
+      logs: [],
+      timestamp: '',
+    }
+    const { worker, createAndSignTx, broadcast } = makeWorker({
       accountInfoResponses: [accountInfo(10), accountInfo(11)],
-      broadcastResult: {
-        code: 11,
-        raw_log:
-          'out of gas in location: ReadFlat; gasWanted: 1856904, gasUsed: 1857904: out of gas',
-        txhash: 'hash',
-      },
+      broadcastResult: successResult,
+    })
+    broadcast.mockResolvedValueOnce({
+      code: 11,
+      raw_log:
+        'out of gas in location: ReadFlat; gasWanted: 1856904, gasUsed: 1857904: out of gas',
+      txhash: 'hash',
     })
 
     expect(worker.gasAdjustment).toBe(1.75)
 
+    // first attempt: signs with base adjustment, fails out of gas, bumps
     await expect(worker.signAndBroadcast([{}])).rejects.toThrow('out of gas')
 
     expect(createAndSignTx).toHaveBeenLastCalledWith({
@@ -223,6 +234,17 @@ describe('WalletWorker account sequence reconciliation', () => {
       gasAdjustment: 1.75,
     })
     expect(worker.gasAdjustment).toBeCloseTo(2.1)
+
+    // retry: signs with the bumped adjustment, succeeds, resets to base
+    await worker.signAndBroadcast([{}])
+
+    expect(createAndSignTx.mock.calls[1][0]).toMatchObject({
+      msgs: [{}],
+      sequence: 11,
+      accountNumber: 7,
+    })
+    expect(createAndSignTx.mock.calls[1][0].gasAdjustment).toBeCloseTo(2.1)
+    expect(worker.gasAdjustment).toBe(1.75)
   })
 
   test('resets gasAdjustment after a successful broadcast', async () => {


### PR DESCRIPTION
## Summary

A tx can pass `CheckTx` and be included in a block but then revert during execution with an out of gas error, e.g.:

```
out of gas in location: ReadFlat; gasWanted: 1856904, gasUsed: 1857904: out of gas
```

(real example: [interwoven-1 tx 445583AA…](https://scan.initia.xyz/interwoven-1/txs/445583AA99704349CF23C7294BF7C95FE0F1E8C8717C9592F4ED0919B143FD5D))

Since `broadcast` waits for block inclusion, this comes back as `isTxError` (`code != 0`). The sequence already advanced, so the existing logic reconciles the sequence and the batch is retried on the next loop. But gas is estimated by simulating the tx and multiplying by a fixed `gasAdjustment` (initia.js default `1.75`), so the retry simulates the same insufficient gas and fails again — an out of gas loop that keeps burning the `gasWanted` fee.

## Change

Track a per-wallet `gasAdjustment` and pass it to `createAndSignTx`:

- On an out of gas failure, bump it by `1.2x` (capped at `4x`).
- On a successful broadcast, reset it to the baseline (`1.75`).

The bumped value applies on the next batch (the relayer re-collects packets every loop), letting the retry go through. Reset-on-success keeps fees minimal in the common case.

## Behavior notes / tradeoff

- **Reset-on-success** means a batch that systematically under-estimates will out-of-gas once, bump, succeed, then reset — so it may re-fail occasionally on a later similar batch. The alternative (sticky adjustment) keeps fees elevated after a single anomaly. Happy to switch to sticky if preferred.
- Detection matches `out of gas` in `raw_log` (case-insensitive).

## Tests

- `increases gasAdjustment after an out of gas error` — first attempt uses `1.75`, adjustment bumped to `2.1` after the failure.
- `resets gasAdjustment after a successful broadcast`.
- Updated the existing success test to assert `gasAdjustment` is passed through.

All 60 tests pass (one unrelated pre-existing suite, `channelOpenTry.spec.ts`, fails to compile on `upgrade_sequence` — untouched here).

## Note

Separate from #67 (stale nonce sequence reconciliation); branched from `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added dynamic gas adjustment for transactions: the system detects out-of-gas broadcast failures, automatically increases gas allocation for subsequent retries (capped to a safe maximum), and resets back to the default after a successful broadcast.
* **Tests**
  * Updated wallet sequence tests to cover gas adjustment behavior, including escalation after out-of-gas errors and reset after success.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->